### PR TITLE
Port pcl_passthrough_filter to ROS2

### DIFF
--- a/pcl_utilities/CMakeLists.txt
+++ b/pcl_utilities/CMakeLists.txt
@@ -44,7 +44,6 @@ if((CMAKE_CXX_COMPILER_ID STREQUAL "Clang" AND
   endif()
 endif()
 
-find_package(PCL REQUIRED)
 # PCL may fail to link with certain environments where
 # `PCL_ROOT` becomes set to '/'.
 # See: https://github.com/PointCloudLibrary/pcl/issues/4661
@@ -57,18 +56,22 @@ find_package(PCL REQUIRED)
 # set(PCL_DIR /usr/lib/x86_64-linux-gnu/cmake/pcl)
 
 find_package(ament_cmake REQUIRED)
-find_package(sensor_msgs REQUIRED)
+find_package(PCL REQUIRED)
+find_package(pcl_conversions REQUIRED)
 find_package(pcl_utility_msgs REQUIRED)
 find_package(pcl_ros REQUIRED)
-find_package(pcl_conversions REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(rcl_interfaces REQUIRED)
+find_package(sensor_msgs REQUIRED)
 
 set(THIS_PACKAGE_DEPS
-  rclcpp
-  sensor_msgs
-  pcl_ros
+  PCL
   pcl_conversions
   pcl_utility_msgs
-  PCL
+  pcl_ros
+  rclcpp
+  rcl_interfaces
+  sensor_msgs
 )
 
 include_directories(${PCL_INCLUDE_DIRS})
@@ -109,10 +112,10 @@ if(BUILD_TESTING)
 
   set(
     THIS_PACKAGE_TEST_DEPS
-    rclcpp
-    sensor_msgs
-    pcl_ros
     pcl_utility_msgs
+    rclcpp
+    rcl_interfaces
+    sensor_msgs
   )
 
   add_executable(simple_test_voxel_grid_filter src/tests/simple_test_voxel_grid_filter.cpp)

--- a/pcl_utilities/CMakeLists.txt
+++ b/pcl_utilities/CMakeLists.txt
@@ -1,6 +1,15 @@
 cmake_minimum_required(VERSION 3.8)
 project(pcl_utilities)
 
+# This code should not be compiled with `-Ofast` or `-ffastmath`
+# for the following reasons:
+#  - These utilities rely on IEEE 754 Compliance.
+#  - PCL uses floating point operations internally, and enabling these
+#    flags can result in unexpected behavior in client code.
+#
+# It is the users responsibility to add the appropriate flags on
+# non Clang/GNU-based compilers (including. non-posix frontend variants.)
+
 if(NOT CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 17)
 endif()
@@ -71,12 +80,16 @@ add_library(${PROJECT_NAME} INTERFACE)
 
 add_executable(voxel_grid_filter_service src/voxel_grid_filter_service.cpp)
 add_executable(concatenate_point_cloud_service src/concatenate_point_cloud_service.cpp)
+add_executable(passthrough_filter_service src/passthrough_filter_service.cpp)
+
 ament_target_dependencies(voxel_grid_filter_service ${THIS_PACKAGE_DEPS})
 ament_target_dependencies(concatenate_point_cloud_service ${THIS_PACKAGE_DEPS})
+ament_target_dependencies(passthrough_filter_service ${THIS_PACKAGE_DEPS})
 
 set(THIS_PACKAGE_EXECS
   voxel_grid_filter_service
   concatenate_point_cloud_service
+  passthrough_filter_service
 )
 
 if(BUILD_TESTING)
@@ -104,13 +117,16 @@ if(BUILD_TESTING)
 
   add_executable(simple_test_voxel_grid_filter src/tests/simple_test_voxel_grid_filter.cpp)
   add_executable(simple_test_concatenate_point_cloud src/tests/simple_test_concatenate_point_cloud.cpp)
+  add_executable(simple_test_passthrough_filter src/tests/simple_test_passthrough_filter.cpp)
 
   ament_target_dependencies(simple_test_voxel_grid_filter ${THIS_PACKAGE_TEST_DEPS})
   ament_target_dependencies(simple_test_concatenate_point_cloud ${THIS_PACKAGE_TEST_DEPS})
+  ament_target_dependencies(simple_test_passthrough_filter ${THIS_PACKAGE_TEST_DEPS})
 
   list(APPEND THIS_PACKAGE_EXECS
     simple_test_voxel_grid_filter
     simple_test_concatenate_point_cloud
+    simple_test_passthrough_filter
   )
 
   find_package(ament_lint_auto REQUIRED)

--- a/pcl_utilities/launch/passthrough_filter.xml
+++ b/pcl_utilities/launch/passthrough_filter.xml
@@ -1,0 +1,20 @@
+<launch>
+    <node
+        pkg="pcl_utilities"
+        exec="passthrough_filter_service"
+        name="passthrough_filter_service"
+        namespace="robot_common_3d/pcl_utilities"
+        output="screen"
+    >
+        <!--
+          Default options are set to a unit cube
+          (max - min) > 0.f must always be true. No values may be NaN
+        -->
+        <param name="filters.passthrough.x.min" value="-0.5" />
+        <param name="filters.passthrough.x.max" value="0.5" />
+        <param name="filters.passthrough.y.min" value="-0.5" />
+        <param name="filters.passthrough.y.max" value="0.5" />
+        <param name="filters.passthrough.z.min" value="-0.5" />
+        <param name="filters.passthrough.z.max" value="0.5" />
+    </node>
+</launch>

--- a/pcl_utilities/launch/tests/test_passthrough_filter.xml
+++ b/pcl_utilities/launch/tests/test_passthrough_filter.xml
@@ -1,0 +1,27 @@
+<launch>
+    <!--
+        Pointcloud is published to the topic: tests/robot_common_3d/pcl_utilities/passthrough_filter/cloud_filtered
+
+        Must launch camera with depth output enabled before this node and
+        specify the ros arg `-\-ros-args point_cloud_topic:=<topic>`
+        example:
+
+        ```
+        ros2 launch realsense2_camera rs_launch.py depth_module.depth_profile:=1280x720x30 pointcloud.enable:=true
+
+        ros2 launch pcl_utilities test_passthrough_filter.xml point_cloud_topic:=/camera/camera/depth/color/points
+        ```
+    -->
+
+    <include file="$(find-pkg-share pcl_utilities)/launch/passthrough_filter.xml" />
+    <node
+        pkg="pcl_utilities"
+        exec="simple_test_passthrough_filter"
+        name="simple_test_passthrough_filter"
+        namespace="/tests/robot_common_3d/pcl_utilities"
+        output="screen"
+    >
+        <param name="node_client_name" value="/robot_common_3d/pcl_utilities/passthrough_filter" />
+        <param name="point_cloud_topic" value="$(var point_cloud_topic)" />
+    </node>
+</launch>

--- a/pcl_utilities/package.xml
+++ b/pcl_utilities/package.xml
@@ -9,9 +9,14 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
-  <depend>rclcpp</depend>
-  <depend>sensor_msgs</depend>
+  <depend>ament_cmake</depend>
+  <depend>pcl</depend>
+  <depend>pcl_conversions</depend>
   <depend>pcl_utility_msgs</depend>
+  <depend>pcl_ros</depend>
+  <depend>rclcpp</depend>
+  <depend>rcl_interfaces</depend>
+  <depend>sensor_msgs</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/pcl_utilities/src/passthrough_filter_service.cpp
+++ b/pcl_utilities/src/passthrough_filter_service.cpp
@@ -163,7 +163,7 @@ public:
     }
 
     std::stringstream message;
-    message << "Passthrough filter bounds do not produce a positive, "
+    message << "Passthrough filter bounds do produce a positive, "
             << "non-zero, non-NaN size:\n"
             << "     X Dimension: " << (x_max_ - y_min_) << "\n"
             << "     Y Dimension: " << (y_max_ - y_min_) << "\n"

--- a/pcl_utilities/src/passthrough_filter_service.cpp
+++ b/pcl_utilities/src/passthrough_filter_service.cpp
@@ -1,0 +1,112 @@
+#include <functional>  // std::bind
+#include <memory>  // std::make_shared
+#include <string_view>  // std::string_view
+#include <utility>  // std::move
+
+#include "rclcpp/node.hpp"
+#include "rclcpp/service.hpp"
+#include "armada_utility_msgs/srv/pcl_passthrough_filter.hpp"
+#include "sensor_msgs/msg/point_cloud2.hpp"
+
+#include "pcl/impl/point_types.hpp"
+#include "pcl/point_cloud2.h"
+#include "pcl/filters/passthrough.h"
+#include "pcl_conversions/pcl_conversions.h"
+
+using armada_utility_msgs::srv::PCLPassthroughFilter;
+constexpr std::string_view g_PARAM_NAMESPACE = "filters.passthrough.";
+
+class PassthroughFilterService : public rclcpp::Node {
+private:
+  rclcpp::Service<PCLPassthroughFilter>::SharedPtr passthrough_filter_service_;
+
+  float x_min_;
+  float x_max_;
+  float y_min_;
+  float y_max_;
+  float z_min_;
+  float z_max_;
+
+public:
+  /**
+   * Class Constructor.
+   *
+   * Constructor for PassthroughFilterService class.
+   */
+  PassthroughFilterService()
+  : rclcpp::Node("passthrough_filter_service")
+  {
+    declare_parameter<float>(g_PARAM_NAMESPACE + "x.min");
+    declare_parameter<float>(g_PARAM_NAMESPACE + "x.max");
+    declare_parameter<float>(g_PARAM_NAMESPACE + "y.min");
+    declare_parameter<float>(g_PARAM_NAMESPACE + "y.max");
+    declare_parameter<float>(g_PARAM_NAMESPACE + "z.min");
+    declare_parameter<float>(g_PARAM_NAMESPACE + "z.max");
+
+    auto callback =
+        std::bind(&PassthroughFilterService::passthrough_filter, this,
+                  std::placeholders::_1, std::placeholders::_2);
+
+    passthrough_filter_service_ =
+      create_service<PCLPassthroughFilter>
+      ("passthrough_filter", std::move(callback));
+  }
+
+  /**
+   * Apply a passthrough (x,y,z) filter to a PointCloud2 message.
+   *
+   * Given a PointCloud2 message, apply a passthrough (x,y,z) filter and
+   * provide the resulting PointCloud2 message. More information about pcl filters at:
+   * https://pcl.readthedocs.io/projects/tutorials/en/master/# This filter:
+   * https://pcl.readthedocs.io/projects/tutorials/en/latest/passthrough.html#passthrough
+   *
+   * @param[in] req sensor_msgs/PointCloud2 A PointCloud2 message.
+   * @param[out] res sensor_msgs/PointCloud2 A PointCloud2 message.
+   * @return Bool Service completion result.
+   */
+  bool passthrough_filter(
+    PCLPassthroughFilter::Request::SharedPtr req,
+    PCLPassthroughFilter::Response::SharedPtr res)
+  {
+    get_parameter(g_PARAM_NAMESPACE + "x.min", x_min_);
+    get_parameter(g_PARAM_NAMESPACE + "x.max", x_max_);
+    get_parameter(g_PARAM_NAMESPACE + "y.min", y_min_);
+    get_parameter(g_PARAM_NAMESPACE + "y.max", y_max_);
+    get_parameter(g_PARAM_NAMESPACE + "z.min", z_min_);
+    get_parameter(g_PARAM_NAMESPACE + "z.max", z_max_);
+
+    pcl::PointCloud<pcl::PointXYZRGB> temp_cloud;
+    moveFromROSMsg(req->cloud_in, temp_cloud);
+
+    pcl::PassThrough<pcl::PointXYZRGB> pass_x;
+    pass_x.setInputCloud(temp_cloud);
+    pass_x.setFilterFieldName("x");
+    pass_x.setFilterLimits(x_min_, x_max_);
+    // pass_x.setFilterLimitsNegative(false);
+    pass_x.filter(temp_cloud);
+
+    pcl::PassThrough<pcl::PointXYZRGB> pass_y;
+    pass_y.setInputCloud(temp_cloud);
+    pass_y.setFilterFieldName("y");
+    pass_y.setFilterLimits(y_min_, y_max_);
+    pass_y.filter(temp_cloud);
+
+    pcl::PassThrough<pcl::PointXYZRGB> pass_z;
+    pass_z.setInputCloud(temp_cloud);
+    pass_z.setFilterFieldName("z");
+    pass_z.setFilterLimits(z_min_, z_max_);
+    pass_z.filter(temp_cloud);
+
+    toROSMsg(temp_cloud, res->cloud_out);
+    return true;
+  }
+};
+
+int main(int argc, char ** argv) {
+  rclcpp::init(argc, argv);
+  auto node = std::make_shared<PassthroughFilterService>();
+  rclcpp::spin(node);
+  rclcpp::shutdown();
+
+  return 0;
+}

--- a/pcl_utilities/src/passthrough_filter_service.cpp
+++ b/pcl_utilities/src/passthrough_filter_service.cpp
@@ -1,22 +1,41 @@
+/*
+ * Author: Brian Flynn
+ * Date: Nov 17, 2022
+ * Editors: Christian Tagliamonte
+ * Last Modified: Aug 15, 2024
+ * Adapted from:
+ * https://github.com/uml-robotics/armada_behaviors/commits/main/armada_flexbe_utilities/src/service/pcl_passthrough_filter_service.cpp
+ *
+ * Description: Starts up a service for filtering point cloud data with a bounding box.
+ *
+ * Input: sensor_msgs/PointCloud2
+ * Output: sensor_msgs/PointCloud2
+ *
+ * Usage:
+ *    `ros2 launch pcl_utilities passthrough_filter.xml`
+ */
 #include <functional>  // std::bind
 #include <memory>  // std::make_shared
+#include <sstream>  // std::stringstream
 #include <string_view>  // std::string_view
 #include <utility>  // std::move
 
-#include "rclcpp/node.hpp"
-#include "rclcpp/service.hpp"
-#include "armada_utility_msgs/srv/pcl_passthrough_filter.hpp"
-#include "sensor_msgs/msg/point_cloud2.hpp"
-
 #include "pcl/impl/point_types.hpp"
-#include "pcl/point_cloud2.h"
+#include "pcl/point_cloud.h"
 #include "pcl/filters/passthrough.h"
 #include "pcl_conversions/pcl_conversions.h"
 
-using armada_utility_msgs::srv::PCLPassthroughFilter;
+#include "rclcpp/node.hpp"
+#include "rclcpp/service.hpp"
+#include "sensor_msgs/msg/point_cloud2.hpp"
+
+#include "pcl_utility_msgs/srv/pcl_passthrough_filter.hpp"
+
+using pcl_utility_msgs::srv::PCLPassthroughFilter;
 constexpr std::string_view g_PARAM_NAMESPACE = "filters.passthrough.";
 
-class PassthroughFilterService : public rclcpp::Node {
+class PassthroughFilterService : public rclcpp::Node
+{
 private:
   rclcpp::Service<PCLPassthroughFilter>::SharedPtr passthrough_filter_service_;
 
@@ -36,20 +55,24 @@ public:
   PassthroughFilterService()
   : rclcpp::Node("passthrough_filter_service")
   {
-    declare_parameter<float>(g_PARAM_NAMESPACE + "x.min");
-    declare_parameter<float>(g_PARAM_NAMESPACE + "x.max");
-    declare_parameter<float>(g_PARAM_NAMESPACE + "y.min");
-    declare_parameter<float>(g_PARAM_NAMESPACE + "y.max");
-    declare_parameter<float>(g_PARAM_NAMESPACE + "z.min");
-    declare_parameter<float>(g_PARAM_NAMESPACE + "z.max");
+    std::string param_namespace {g_PARAM_NAMESPACE};
 
-    auto callback =
-        std::bind(&PassthroughFilterService::passthrough_filter, this,
-                  std::placeholders::_1, std::placeholders::_2);
+    x_min_ = declare_parameter<float>(param_namespace + "x.min");
+    x_max_ = declare_parameter<float>(param_namespace + "x.max");
+    y_min_ = declare_parameter<float>(param_namespace + "y.min");
+    y_max_ = declare_parameter<float>(param_namespace + "y.max");
+    z_min_ = declare_parameter<float>(param_namespace + "z.min");
+    z_max_ = declare_parameter<float>(param_namespace + "z.max");
 
-    passthrough_filter_service_ =
-      create_service<PCLPassthroughFilter>
-      ("passthrough_filter", std::move(callback));
+    // do not shutdown so all memory is cleaned up before exit
+    check_for_valid_limits();
+
+    auto callback = std::bind(
+      &PassthroughFilterService::passthrough_filter, this,
+      std::placeholders::_1, std::placeholders::_2);
+
+    passthrough_filter_service_ = create_service<PCLPassthroughFilter>(
+      "passthrough_filter", std::move(callback));
   }
 
   /**
@@ -68,41 +91,92 @@ public:
     PCLPassthroughFilter::Request::SharedPtr req,
     PCLPassthroughFilter::Response::SharedPtr res)
   {
-    get_parameter(g_PARAM_NAMESPACE + "x.min", x_min_);
-    get_parameter(g_PARAM_NAMESPACE + "x.max", x_max_);
-    get_parameter(g_PARAM_NAMESPACE + "y.min", y_min_);
-    get_parameter(g_PARAM_NAMESPACE + "y.max", y_max_);
-    get_parameter(g_PARAM_NAMESPACE + "z.min", z_min_);
-    get_parameter(g_PARAM_NAMESPACE + "z.max", z_max_);
+    // Retrieve and validate all parameters
+    std::string param_namespace {g_PARAM_NAMESPACE};
 
-    pcl::PointCloud<pcl::PointXYZRGB> temp_cloud;
-    moveFromROSMsg(req->cloud_in, temp_cloud);
+    get_parameter(param_namespace + "x.min", x_min_);
+    get_parameter(param_namespace + "x.max", x_max_);
+    get_parameter(param_namespace + "y.min", y_min_);
+    get_parameter(param_namespace + "y.max", y_max_);
+    get_parameter(param_namespace + "z.min", z_min_);
+    get_parameter(param_namespace + "z.max", z_max_);
+
+    if (!check_for_valid_limits()) {
+      rclcpp::shutdown();
+      return false;
+    }
+
+    auto temp_cloud = std::make_shared<pcl::PointCloud<pcl::PointXYZRGB>>();
+
+    std::string frame_id = req->cloud_in.header.frame_id;
+    moveFromROSMsg(req->cloud_in, *temp_cloud);
 
     pcl::PassThrough<pcl::PointXYZRGB> pass_x;
     pass_x.setInputCloud(temp_cloud);
     pass_x.setFilterFieldName("x");
     pass_x.setFilterLimits(x_min_, x_max_);
     // pass_x.setFilterLimitsNegative(false);
-    pass_x.filter(temp_cloud);
+    pass_x.filter(*temp_cloud);
 
     pcl::PassThrough<pcl::PointXYZRGB> pass_y;
     pass_y.setInputCloud(temp_cloud);
     pass_y.setFilterFieldName("y");
     pass_y.setFilterLimits(y_min_, y_max_);
-    pass_y.filter(temp_cloud);
+    pass_y.filter(*temp_cloud);
 
     pcl::PassThrough<pcl::PointXYZRGB> pass_z;
     pass_z.setInputCloud(temp_cloud);
     pass_z.setFilterFieldName("z");
     pass_z.setFilterLimits(z_min_, z_max_);
-    pass_z.filter(temp_cloud);
+    pass_z.filter(*temp_cloud);
 
-    toROSMsg(temp_cloud, res->cloud_out);
+    // preseve the TF frame in the output
+    toROSMsg(*temp_cloud, res->cloud_out);
+    res->cloud_out.header.frame_id = std::move(frame_id);
+
     return true;
+  }
+
+  /**
+   * Checks whether the dimensions provided as parameters are valid,
+   * If not, then then this message prints an error message and returns
+   * false.
+   *
+   * Note: This function must be called after all the values are initialized.
+   *
+   * Side-effects: this program uses the state of `this` and prints to std::stderr.
+   * @returns
+   *  a boolean indicating whether the variables are valid.
+   *
+   */
+  bool check_for_valid_limits() const
+  {
+    // Checks to make sure all inputs have a positive size
+    // Must use `!` instead since all comparisons over NaN are
+    // implitely false, so this condition catches this case.
+    if (
+      x_max_ - x_min_ > 0.f &&
+      y_max_ - y_min_ > 0.f &&
+      z_max_ - z_min_ > 0.f)
+    {
+      return true;
+    }
+
+    std::stringstream message;
+    message << "Passthrough filter bounds do not produce a positive, "
+            << "non-zero, non-NaN size:\n"
+            << "     X Dimension: " << (x_max_ - y_min_) << "\n"
+            << "     Y Dimension: " << (y_max_ - y_min_) << "\n"
+            << "     Z Dimension: " << (z_max_ - z_min_) << "\n";
+
+    RCLCPP_FATAL_STREAM(get_logger(), message.str());
+
+    return false;
   }
 };
 
-int main(int argc, char ** argv) {
+int main(int argc, char ** argv)
+{
   rclcpp::init(argc, argv);
   auto node = std::make_shared<PassthroughFilterService>();
   rclcpp::spin(node);

--- a/pcl_utilities/src/passthrough_filter_service.cpp
+++ b/pcl_utilities/src/passthrough_filter_service.cpp
@@ -2,7 +2,7 @@
  * Author: Brian Flynn
  * Date: Nov 17, 2022
  * Editors: Christian Tagliamonte
- * Last Modified: Aug 15, 2024
+ * Last Modified: Aug 19, 2024
  * Adapted from:
  * https://github.com/uml-robotics/armada_behaviors/commits/main/armada_flexbe_utilities/src/service/pcl_passthrough_filter_service.cpp
  *

--- a/pcl_utilities/src/tests/simple_test_passthrough_filter.cpp
+++ b/pcl_utilities/src/tests/simple_test_passthrough_filter.cpp
@@ -2,7 +2,7 @@
  * Author: Christian Tagliamonte
  * Date: Aug 15, 2024
  * Editors: N/A
- * Last Modified: Aug 15, 2024
+ * Last Modified: Aug 19, 2024
  *
  * Description: A node to test the passthrough_filter_service.
  * This node listens to point cloud data from a camera

--- a/pcl_utilities/src/tests/simple_test_passthrough_filter.cpp
+++ b/pcl_utilities/src/tests/simple_test_passthrough_filter.cpp
@@ -1,0 +1,125 @@
+/*
+ * Author: Christian Tagliamonte
+ * Date: Aug 15, 2024
+ * Editors: N/A
+ * Last Modified: Aug 15, 2024
+ *
+ * Description: A node to test the passthrough_filter_service.
+ * This node listens to point cloud data from a camera
+ *   messages from the topic specified by the parameter, `point_cloud_topic.`
+ * The point cloud is passed to the service, where all points outside of a bounding box
+ * are removed. The bounds for the passthrough filter are controlled via ros parameters,
+ * these parameters default to the shape of 1x1x1 meter unit-cube centered at (0, 0, 0).
+ *
+ * NOTES:
+ * - That all of these parameters must produce a volume with a positive, non-zero size.
+ * - None of the paramters can be NaN.
+ * The node will crash if invalid input is passed to these parameters.
+ *
+ * The filtered point cloud is then published to the topic
+ *   `test_passthrough_filter_service/passthrough_filtered`
+ *
+ * Usage:
+ *    `ros2 launch pcl_utilities test_passthrough_filter_service.xml point_cloud_topic:=<POINT_CLOUD_TOPIC>`
+ */
+#include <chrono>   // std::chrono::seconds
+#include <cstddef>  // size_t
+#include <cstdint>  // int64_t
+#include <functional>  // std::bind, std::placeholders
+#include <ios>  // std::fixed, std::setprecision
+#include <memory>  // std::make_shared
+#include <sstream>  // std::stringstream
+#include <string>
+#include <utility>  // std::move
+
+#include "rclcpp/executors.hpp"
+#include "rclcpp/logger.hpp"
+#include "rclcpp/logging.hpp"
+#include "rclcpp/node.hpp"
+#include "rclcpp/publisher.hpp"
+#include "rclcpp/subscription.hpp"
+#include "rclcpp/wait_for_message.hpp"
+
+#include "sensor_msgs/msg/point_cloud2.hpp"
+
+#include "pcl_utility_msgs/srv/pcl_passthrough_filter.hpp"
+
+using pcl_utility_msgs::srv::PCLPassthroughFilter;
+using sensor_msgs::msg::PointCloud2;
+
+constexpr std::chrono::seconds MAX_WAIT_TIME {1U};
+
+class TestPassthroughFilterNode : public rclcpp::Node
+{
+private:
+  rclcpp::Client<PCLPassthroughFilter>::SharedPtr
+    passthrough_filter_client_;
+  rclcpp::Publisher<PointCloud2>::SharedPtr output_publisher_;
+  std::string camera_topic_;
+
+public:
+  TestPassthroughFilterNode()
+  : rclcpp::Node("simple_test_passthrough_filter")
+  {
+    std::string client_topic = declare_parameter<std::string>("node_client_name");
+    camera_topic_ = declare_parameter<std::string>("point_cloud_topic");
+
+    passthrough_filter_client_ =
+      create_client<PCLPassthroughFilter>(client_topic);
+
+    output_publisher_ = create_publisher<PointCloud2>(
+      "test_passthrough_filter_service/cloud_filtered", 1);
+  }
+
+  void spin()
+  {
+    while (rclcpp::ok()) {
+      PointCloud2 point_cloud_message;
+
+      bool was_retrieved = rclcpp::wait_for_message(
+        point_cloud_message, shared_from_this(),
+        camera_topic_, MAX_WAIT_TIME);
+
+      if (!was_retrieved) {
+        RCLCPP_ERROR_STREAM(
+          get_logger(),
+          "A camera message could not be retrieved within 1 second.");
+        continue;
+      }
+
+      process_point_cloud(point_cloud_message);
+    }
+  }
+
+  void process_point_cloud(PointCloud2 & point_cloud)
+  {
+    auto request = std::make_shared<PCLPassthroughFilter::Request>();
+    request->cloud_in = std::move(point_cloud);
+
+    auto response_future =
+      passthrough_filter_client_->async_send_request(request);
+
+    auto response_code = rclcpp::spin_until_future_complete(
+      shared_from_this(), response_future, MAX_WAIT_TIME);
+
+    if (response_code != rclcpp::FutureReturnCode::SUCCESS) {
+      RCLCPP_ERROR_STREAM(get_logger(), "Failed to recieve a response from the service");
+      return;
+    }
+
+    PCLPassthroughFilter::Response::SharedPtr response {
+      response_future.get()};
+    output_publisher_->publish(response->cloud_out);
+  }
+};
+
+int main(int argc, char ** argv)
+{
+  rclcpp::init(argc, argv);
+
+  auto node = std::make_shared<TestPassthroughFilterNode>();
+  node->spin();
+
+  rclcpp::shutdown();
+  return 0;
+}

--- a/pcl_utilities/src/tests/simple_test_passthrough_filter.cpp
+++ b/pcl_utilities/src/tests/simple_test_passthrough_filter.cpp
@@ -87,14 +87,14 @@ public:
         continue;
       }
 
-      process_point_cloud(point_cloud_message);
+      process_point_cloud(std::move(point_cloud_message));
     }
   }
 
-  void process_point_cloud(PointCloud2 & point_cloud)
+  void process_point_cloud(PointCloud2 && point_cloud)
   {
     auto request = std::make_shared<PCLPassthroughFilter::Request>();
-    request->cloud_in = std::move(point_cloud);
+    request->cloud_in = point_cloud;
 
     auto response_future =
       passthrough_filter_client_->async_send_request(request);

--- a/pcl_utilities/src/tests/simple_test_passthrough_filter.cpp
+++ b/pcl_utilities/src/tests/simple_test_passthrough_filter.cpp
@@ -23,12 +23,7 @@
  *    `ros2 launch pcl_utilities test_passthrough_filter_service.xml point_cloud_topic:=<POINT_CLOUD_TOPIC>`
  */
 #include <chrono>   // std::chrono::seconds
-#include <cstddef>  // size_t
-#include <cstdint>  // int64_t
-#include <functional>  // std::bind, std::placeholders
-#include <ios>  // std::fixed, std::setprecision
 #include <memory>  // std::make_shared
-#include <sstream>  // std::stringstream
 #include <string>
 #include <utility>  // std::move
 

--- a/pcl_utility_msgs/CMakeLists.txt
+++ b/pcl_utility_msgs/CMakeLists.txt
@@ -26,6 +26,7 @@ find_package(rosidl_default_generators REQUIRED)
 rosidl_generate_interfaces(${PROJECT_NAME}
   "srv/PCLVoxelGridFilter.srv"
   "srv/PCLConcatenatePointCloud.srv"
+  "srv/PCLPassthroughFilter.srv"
   DEPENDENCIES sensor_msgs
 )
 

--- a/pcl_utility_msgs/srv/PCLPassthroughFilter.srv
+++ b/pcl_utility_msgs/srv/PCLPassthroughFilter.srv
@@ -1,0 +1,3 @@
+sensor_msgs/PointCloud2 cloud_in
+---
+sensor_msgs/PointCloud2 cloud_out


### PR DESCRIPTION
# Changes Made
## passthrough_filter_service:
- Introduced class format, moved main functionality to the constructor, and marked data private.
- Added missing header files.
- Added error checking for all input parameters: all parameters must produce a volumn with a
  positive, non-zero, non-NaN size. Node will shutdown on error. This was moved to its own
  function.
- Convert `fromROSMsg` -> `moveFromROSMsg`.
- Preserve TF frame information in the result.
- replace explicit `std::shared_ptr(new TYPE) ` with definition with `std::make_shared<TYPE>()` format.
- Convert parameter namespace to `std::string_view` to follow google style guidelines.

## simple_test_passthrough_filter:
 - Omit explicit test checks. This script is harder to test accurately since its very sensitive to input data. However, it's easy to verify the code works visually which is included in the script. These tests will be replaced anyways with dedicated unit tests so these can be omitted for now.

## Setup
- Works on `g++ 11.4.0`, `clang++ 19`, and `icpx 2024.2.1`.
- Lints Properly.
- No Valgrind and sanitizer checks yet.

## Misc
- `CMakeLists.txt`: Added notes about why the program must not use `-Ofast` or `-ffast-math`
- `CMakeLists.txt`: Added the new files so they can be built
- Added two new launch files. These are mostly the same as with other commits. The default parameters for the bounding box in passthrough_filter default to a `1x1x1 m` cube centered at `(0, 0, 0)` 

# Evidence of Working Code
The darker background is the entire field of view of the camera, while the bright color segments only contain the filtered points. The default settings are used.
![ezgif-7-fc5fa396ea](https://github.com/user-attachments/assets/e4a3cabe-484f-4bb2-95f0-a48301307064)
When the arrow is moved up, it falls within the bound of the bottom of the bounding box so the colors appear brighter on the image.
