### PR TITLE
Port transform_point_cloud function to ROS2

### DIFF
--- a/pcl_utilities/CMakeLists.txt
+++ b/pcl_utilities/CMakeLists.txt
@@ -35,7 +35,6 @@ if((CMAKE_CXX_COMPILER_ID STREQUAL "Clang" AND
   endif()
 endif()
 
-find_package(PCL REQUIRED)
 # PCL may fail to link with certain environments where
 # `PCL_ROOT` becomes set to '/'.
 # See: https://github.com/PointCloudLibrary/pcl/issues/4661
@@ -48,18 +47,28 @@ find_package(PCL REQUIRED)
 # set(PCL_DIR /usr/lib/x86_64-linux-gnu/cmake/pcl)
 
 find_package(ament_cmake REQUIRED)
-find_package(sensor_msgs REQUIRED)
-find_package(pcl_utility_msgs REQUIRED)
-find_package(pcl_ros REQUIRED)
+find_package(geometry_msgs REQUIRED)
+find_package(PCL REQUIRED)
 find_package(pcl_conversions REQUIRED)
+find_package(pcl_ros REQUIRED)
+find_package(pcl_utility_msgs REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(rcl_interfaces REQUIRED)
+find_package(sensor_msgs REQUIRED)
+find_package(tf2_ros REQUIRED)
+find_package(tf2_sensor_msgs)
 
 set(THIS_PACKAGE_DEPS
-  rclcpp
-  sensor_msgs
-  pcl_ros
-  pcl_conversions
-  pcl_utility_msgs
+  geometry_msgs
   PCL
+  pcl_conversions
+  pcl_ros
+  pcl_utility_msgs
+  rclcpp
+  rcl_interfaces
+  sensor_msgs
+  tf2_ros
+  tf2_sensor_msgs
 )
 
 include_directories(${PCL_INCLUDE_DIRS})
@@ -71,12 +80,16 @@ add_library(${PROJECT_NAME} INTERFACE)
 
 add_executable(voxel_grid_filter_service src/voxel_grid_filter_service.cpp)
 add_executable(concatenate_point_cloud_service src/concatenate_point_cloud_service.cpp)
+add_executable(transform_point_cloud_service src/transform_point_cloud_service.cpp)
+
 ament_target_dependencies(voxel_grid_filter_service ${THIS_PACKAGE_DEPS})
 ament_target_dependencies(concatenate_point_cloud_service ${THIS_PACKAGE_DEPS})
+ament_target_dependencies(transform_point_cloud_service ${THIS_PACKAGE_DEPS})
 
 set(THIS_PACKAGE_EXECS
   voxel_grid_filter_service
   concatenate_point_cloud_service
+  transform_point_cloud_service
 )
 
 if(BUILD_TESTING)
@@ -86,31 +99,30 @@ if(BUILD_TESTING)
   if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     # these options will make debugging memory issues and undefined behavior easier
     # -g3 -O0 : make debugging easier using GDB
-    # -fstack-protector-all : will crash if stack corruption is detected
     # -D FORTIFY_SOURCE=2 : adds memory corruption protections
-    # -ftrapv : detects signed overflow which is undefined per the C++ standard
-    # -Wl,-z,relro : a linker flag to move immutable memory into ROM which
-    #     will help detect invalid writes
-    add_compile_options(-g3 -O0 -D FORTIFY_SOURCE=2)
+    add_compile_options(-g3 -O0 -D_FORTIFY_SOURCE=2)
   endif()
 
   set(
     THIS_PACKAGE_TEST_DEPS
-    rclcpp
-    sensor_msgs
     pcl_ros
     pcl_utility_msgs
+    rclcpp
+    sensor_msgs
   )
 
   add_executable(simple_test_voxel_grid_filter src/tests/simple_test_voxel_grid_filter.cpp)
   add_executable(simple_test_concatenate_point_cloud src/tests/simple_test_concatenate_point_cloud.cpp)
+  add_executable(simple_test_transform_point_cloud src/tests/simple_test_transform_point_cloud.cpp)
 
   ament_target_dependencies(simple_test_voxel_grid_filter ${THIS_PACKAGE_TEST_DEPS})
   ament_target_dependencies(simple_test_concatenate_point_cloud ${THIS_PACKAGE_TEST_DEPS})
+  ament_target_dependencies(simple_test_transform_point_cloud ${THIS_PACKAGE_TEST_DEPS})
 
   list(APPEND THIS_PACKAGE_EXECS
     simple_test_voxel_grid_filter
     simple_test_concatenate_point_cloud
+    simple_test_transform_point_cloud
   )
 
   find_package(ament_lint_auto REQUIRED)
@@ -133,7 +145,7 @@ install(TARGETS
 )
 
 install(DIRECTORY launch
-  DESTINATION share/${PROJECT_NAME}/
+  DESTINATION share/${PROJECT_NAME}
 )
 
 ament_export_targets("export_${PROJECT_NAME}")

--- a/pcl_utilities/launch/tests/test_transform_point_cloud.xml
+++ b/pcl_utilities/launch/tests/test_transform_point_cloud.xml
@@ -1,0 +1,27 @@
+<launch>
+    <!--
+        Pointcloud is published to the topic: tests/robot_common_3d/pcl_utilities/transform_point_cloud/cloud_transformed
+
+        Must launch camera with depth output enabled before this node and
+        specify the ros arg `-\-ros-args point_cloud_topic:=<topic>`
+        example:
+
+        ```
+        ros2 launch realsense2_camera rs_launch.py depth_module.depth_profile:=1280x720x30 pointcloud.enable:=true
+
+        ros2 launch pcl_utilities test_transform_point_cloud.xml point_cloud_topic:=/camera/camera/depth/color/points
+        ```
+    -->
+
+    <arg name="point_cloud_topic" />
+    <include file="$(find-pkg-share pcl_utilities)/launch/transform_point_cloud.xml" />
+    <node
+        pkg="pcl_utilities"
+        exec="simple_test_transform_point_cloud"
+        name="simple_test_transform_point_cloud"
+        namespace="/tests/robot_common_3d/pcl_utilities"
+    >
+        <param name="node_client_name" value="/robot_common_3d/pcl_utilities/transform_point_cloud" />
+        <param name="point_cloud_topic" value="$(var point_cloud_topic)" />
+    </node>
+</launch>

--- a/pcl_utilities/launch/tests/test_transform_point_cloud.xml
+++ b/pcl_utilities/launch/tests/test_transform_point_cloud.xml
@@ -14,6 +14,7 @@
     -->
 
     <arg name="point_cloud_topic" />
+    <arg name="source_frame_name" default="/camera_link" />
     <include file="$(find-pkg-share pcl_utilities)/launch/transform_point_cloud.xml" />
     <node
         pkg="pcl_utilities"
@@ -23,5 +24,6 @@
     >
         <param name="node_client_name" value="/robot_common_3d/pcl_utilities/transform_point_cloud" />
         <param name="point_cloud_topic" value="$(var point_cloud_topic)" />
+        <param name="source_frame_name" value="$(var source_frame_name)" />
     </node>
 </launch>

--- a/pcl_utilities/launch/transform_point_cloud.xml
+++ b/pcl_utilities/launch/transform_point_cloud.xml
@@ -1,0 +1,11 @@
+<launch>
+    <node
+        pkg="pcl_utilities"
+        exec="transform_point_cloud_service"
+        name="transform_point_cloud"
+        namespace="robot_common_3d/pcl_utilities"
+        output="screen"
+    >
+        <param name="max_transform_attempts" value="8" />
+    </node>
+</launch>

--- a/pcl_utilities/package.xml
+++ b/pcl_utilities/package.xml
@@ -9,9 +9,15 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
-  <depend>rclcpp</depend>
-  <depend>sensor_msgs</depend>
+  <depend>geometry_msgs</depend>
+  <depend>pcl</depend>
+  <depend>pcl_conversions</depend>
+  <depend>pcl_ros</depend>
   <depend>pcl_utility_msgs</depend>
+  <depend>rclcpp</depend>
+  <depend>rcl_interfaces</depend>
+  <depend>sensor_msgs</depend>
+  <depend>tf2_ros</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/pcl_utilities/src/tests/simple_test_transform_point_cloud.cpp
+++ b/pcl_utilities/src/tests/simple_test_transform_point_cloud.cpp
@@ -7,6 +7,11 @@
  * Description: A node to test the concatenate_point_cloud_service.
  * This node listens a point cloud message, then transforms the frame of the
  * point cloud, and publishes the resulting topic.
+ * This script takes in two parameters:
+ *    `source_frame_name` = The frame to transform from
+ *    `point_cloud_topic` = The topic name to read point cloud images from
+ * Note: The target TF frame is dynamically generated and not controlled
+ * by a parameter.
  *
  * The transformed point cloud is then published to the topic
  *   `transform_point_cloud/cloud_transformed`

--- a/pcl_utilities/src/tests/simple_test_transform_point_cloud.cpp
+++ b/pcl_utilities/src/tests/simple_test_transform_point_cloud.cpp
@@ -1,3 +1,19 @@
+/*
+ * Author: Christian Tagliamonte
+ * Date: Aug Aug 16, 2024
+ * Editors: N/A
+ * Last Modified: Aug 19, 2024
+ *
+ * Description: A node to test the concatenate_point_cloud_service.
+ * This node listens a point cloud message, then transforms the frame of the
+ * point cloud, and publishes the resulting topic.
+ *
+ * The transformed point cloud is then published to the topic
+ *   `transform_point_cloud/cloud_transformed`
+ *
+ * Usage:
+ *    `ros2 launch pcl_utilities test_transform_point_cloud.xml point_cloud_topic:=<POINT_CLOUD_TOPIC>`
+ */
 #include <chrono>   // std::chrono::seconds
 #include <cstdint>  // int64_t
 #include <functional>  // std::bind, std::placeholders
@@ -39,13 +55,15 @@ private:
   rclcpp::Publisher<PointCloud2>::SharedPtr output_publisher_;
   std::string camera_topic_;
   std::string target_frame_name_;
+  std::string source_frame_name_;
 
 public:
   TestTransformPointCloudNode()
   : rclcpp::Node("simple_test_transform_point_cloud"),
-    tf_broadcaster_(*static_cast<rclcpp::Node*>(this))
+    tf_broadcaster_(*static_cast<rclcpp::Node *>(this))
   {
     std::string client_topic = declare_parameter<std::string>("node_client_name");
+    source_frame_name_ = declare_parameter<std::string>("source_frame_name");
     camera_topic_ = declare_parameter<std::string>("point_cloud_topic");
 
     transform_point_cloud_client_ =
@@ -80,7 +98,7 @@ public:
   {
     // Send a recent transform for the service to use
     TransformStamped tf_transform;
-    tf_transform.header.frame_id = "/camera_link";
+    tf_transform.header.frame_id = source_frame_name_;
     tf_transform.child_frame_id = target_frame_name_;
     tf_transform.header.stamp = get_clock()->now();
 

--- a/pcl_utilities/src/tests/simple_test_transform_point_cloud.cpp
+++ b/pcl_utilities/src/tests/simple_test_transform_point_cloud.cpp
@@ -4,8 +4,8 @@
  * Editors: N/A
  * Last Modified: Aug 19, 2024
  *
- * Description: A node to test the concatenate_point_cloud_service.
- * This node listens a point cloud message, then transforms the frame of the
+ * Description: A node to test the transform_point_cloud_service.
+ * This node listens to a point cloud message, then transforms the frame of the
  * point cloud, and publishes the resulting topic.
  * This script takes in two parameters:
  *    `source_frame_name` = The frame to transform from
@@ -20,13 +20,7 @@
  *    `ros2 launch pcl_utilities test_transform_point_cloud.xml point_cloud_topic:=<POINT_CLOUD_TOPIC>`
  */
 #include <chrono>   // std::chrono::seconds
-#include <cstdint>  // int64_t
-#include <functional>  // std::bind, std::placeholders
-#include <ios>  // std::fixed, std::setprecision
 #include <memory>  // std::make_shared
-#include <optional>  // std::optional
-#include <random>
-#include <sstream>  // std::stringstream
 #include <string>
 #include <utility>  // std::move
 

--- a/pcl_utilities/src/tests/simple_test_transform_point_cloud.cpp
+++ b/pcl_utilities/src/tests/simple_test_transform_point_cloud.cpp
@@ -29,7 +29,6 @@
 #include "rclcpp/logging.hpp"
 #include "rclcpp/node.hpp"
 #include "rclcpp/publisher.hpp"
-#include "rclcpp/subscription.hpp"
 #include "rclcpp/wait_for_message.hpp"
 #include "sensor_msgs/msg/point_cloud2.hpp"
 #include "geometry_msgs/msg/transform_stamped.hpp"

--- a/pcl_utilities/src/tests/simple_test_transform_point_cloud.cpp
+++ b/pcl_utilities/src/tests/simple_test_transform_point_cloud.cpp
@@ -1,0 +1,122 @@
+#include <chrono>   // std::chrono::seconds
+#include <cstdint>  // int64_t
+#include <functional>  // std::bind, std::placeholders
+#include <ios>  // std::fixed, std::setprecision
+#include <memory>  // std::make_shared
+#include <optional>  // std::optional
+#include <random>
+#include <sstream>  // std::stringstream
+#include <string>
+#include <utility>  // std::move
+
+#include "rclcpp/executors.hpp"
+#include "rclcpp/logger.hpp"
+#include "rclcpp/logging.hpp"
+#include "rclcpp/node.hpp"
+#include "rclcpp/publisher.hpp"
+#include "rclcpp/subscription.hpp"
+#include "rclcpp/wait_for_message.hpp"
+#include "sensor_msgs/msg/point_cloud2.hpp"
+#include "geometry_msgs/msg/transform_stamped.hpp"
+
+#include "tf2_ros/buffer.h"
+#include "tf2_ros/transform_broadcaster.h"
+
+#include "pcl_utility_msgs/srv/pcl_transform_point_cloud.hpp"
+
+using pcl_utility_msgs::srv::PCLTransformPointCloud;
+using sensor_msgs::msg::PointCloud2;
+using geometry_msgs::msg::TransformStamped;
+
+constexpr std::chrono::seconds MAX_WAIT_TIME {1U};
+
+class TestTransformPointCloudNode : public rclcpp::Node
+{
+private:
+  tf2_ros::TransformBroadcaster tf_broadcaster_;
+  rclcpp::Client<PCLTransformPointCloud>::SharedPtr
+    transform_point_cloud_client_;
+  rclcpp::Publisher<PointCloud2>::SharedPtr output_publisher_;
+  std::string camera_topic_;
+  std::string target_frame_name_;
+
+public:
+  TestTransformPointCloudNode()
+  : rclcpp::Node("simple_test_transform_point_cloud"),
+    tf_broadcaster_(*static_cast<rclcpp::Node*>(this))
+  {
+    std::string client_topic = declare_parameter<std::string>("node_client_name");
+    camera_topic_ = declare_parameter<std::string>("point_cloud_topic");
+
+    transform_point_cloud_client_ =
+      create_client<PCLTransformPointCloud>(client_topic);
+
+    output_publisher_ = create_publisher<PointCloud2>(
+      "transform_point_cloud/cloud_transformed", 1);
+
+    target_frame_name_ = std::string(get_name()) + "_tf_frame";
+  }
+
+  void spin()
+  {
+    while (rclcpp::ok()) {
+      PointCloud2 point_cloud_message;
+      bool was_retrieved = rclcpp::wait_for_message(
+        point_cloud_message, shared_from_this(),
+        camera_topic_, MAX_WAIT_TIME);
+
+      if (!was_retrieved) {
+        RCLCPP_ERROR_STREAM(
+          get_logger(),
+          "A camera message could not be retrieved within 1 second.");
+        continue;
+      }
+
+      process_point_cloud(std::move(point_cloud_message));
+    }
+  }
+
+  void process_point_cloud(PointCloud2 && point_cloud)
+  {
+    // Send a recent transform for the service to use
+    TransformStamped tf_transform;
+    tf_transform.header.frame_id = "/camera_link";
+    tf_transform.child_frame_id = target_frame_name_;
+    tf_transform.header.stamp = get_clock()->now();
+
+    tf_transform.transform.rotation.w = 1.0;
+    tf_transform.transform.translation.x = 5.0;
+
+    tf_broadcaster_.sendTransform(std::move(tf_transform));
+
+    auto request = std::make_shared<PCLTransformPointCloud::Request>();
+    request->target_frame = target_frame_name_;
+    request->cloud_in = point_cloud;
+
+    auto response_future =
+      transform_point_cloud_client_->async_send_request(request);
+
+    auto response_code = rclcpp::spin_until_future_complete(
+      shared_from_this(), response_future, MAX_WAIT_TIME);
+
+    if (response_code != rclcpp::FutureReturnCode::SUCCESS) {
+      RCLCPP_ERROR_STREAM(get_logger(), "Failed to recieve a response from the service");
+      return;
+    }
+
+    PCLTransformPointCloud::Response::SharedPtr response {
+      response_future.get()};
+    output_publisher_->publish(response->cloud_out);
+  }
+};
+
+int main(int argc, char ** argv)
+{
+  rclcpp::init(argc, argv);
+
+  auto node = std::make_shared<TestTransformPointCloudNode>();
+  node->spin();
+
+  rclcpp::shutdown();
+  return 0;
+}

--- a/pcl_utilities/src/tests/simple_test_transform_point_cloud.cpp
+++ b/pcl_utilities/src/tests/simple_test_transform_point_cloud.cpp
@@ -33,7 +33,6 @@
 #include "sensor_msgs/msg/point_cloud2.hpp"
 #include "geometry_msgs/msg/transform_stamped.hpp"
 
-#include "tf2_ros/buffer.h"
 #include "tf2_ros/transform_broadcaster.h"
 
 #include "pcl_utility_msgs/srv/pcl_transform_point_cloud.hpp"

--- a/pcl_utilities/src/transform_point_cloud_service.cpp
+++ b/pcl_utilities/src/transform_point_cloud_service.cpp
@@ -27,8 +27,6 @@
 
 #include "rclcpp/logging.hpp"
 #include "rclcpp/node.hpp"
-#include "rcl_interfaces/msg/integer_range.hpp"
-#include "rcl_interfaces/msg/parameter_descriptor.hpp"
 #include "sensor_msgs/msg/point_cloud2.hpp"
 
 #include "tf2_ros/buffer.h"
@@ -51,20 +49,7 @@ public:
   : rclcpp::Node("transform_point_cloud_service"),
     tf_buffer_(get_clock()), tf_listener_(tf_buffer_)
   {
-    // -1 signals an infinite number of attempts
-    // If a value is set to above this, it should probably be -1
-    constexpr int64_t MAX_REASONABLE_TRANSFORM_ATTEMPTS = 500;
-
-    // Setup ROS parameters
-    rcl_interfaces::msg::ParameterDescriptor param_constraints;
-    rcl_interfaces::msg::IntegerRange integer_range;
-
-    integer_range.from_value = -1;
-    integer_range.to_value = MAX_REASONABLE_TRANSFORM_ATTEMPTS;
-    param_constraints.integer_range.push_back(integer_range);
-
-    max_transforms_ = declare_parameter<int64_t>(
-      "max_transform_attempts", std::move(param_constraints));
+    max_transforms_ = declare_parameter<int64_t>("max_transform_attempts");
 
     // Attach the callback
     auto callback = std::bind(

--- a/pcl_utilities/src/transform_point_cloud_service.cpp
+++ b/pcl_utilities/src/transform_point_cloud_service.cpp
@@ -1,0 +1,130 @@
+/*
+ * Author: Daniel Maccaline
+ * Date: Apr 1, 2024
+ * Editors: Christian Tagliamonte
+ * Last Modified: Aug 16, 2024
+ * Adapted from:
+ * https://github.com/uml-robotics/SpotCommonBehaviors/commits/main/widget_detect_and_grab/include/widget_detect_and_grab/WidgetDetector.hpp
+ *
+ * Description: Starts up a service for transforming point cloud messages.
+ *
+ * Input: sensor_msgs/PointCloud2
+ * Output: sensor_msgs/PointCloud2
+ *
+ * Usage:
+ *    `ros2 launch pcl_utilities transform_point_cloud.xml`
+ */
+
+#include <cstdint>  // std::int64_t
+#include <functional>  // std::bind
+#include <iomanip>  // std::quoted
+#include <memory>  // std::make_shared
+#include <sstream>  // std::stringstream
+#include <string>
+#include <utility>  // std::move
+
+#include "pcl_utility_msgs/srv/pcl_transform_point_cloud.hpp"
+
+#include "rclcpp/logging.hpp"
+#include "rclcpp/node.hpp"
+#include "rcl_interfaces/msg/integer_range.hpp"
+#include "rcl_interfaces/msg/parameter_descriptor.hpp"
+#include "sensor_msgs/msg/point_cloud2.hpp"
+
+#include "tf2_ros/buffer.h"
+#include "tf2_ros/transform_listener.h"
+#include "tf2_sensor_msgs/tf2_sensor_msgs.hpp"  // tf2::doTransform
+
+using pcl_utility_msgs::srv::PCLTransformPointCloud;
+
+class TransformPointCloudService : public rclcpp::Node
+{
+private:
+  tf2_ros::Buffer tf_buffer_;
+  tf2_ros::TransformListener tf_listener_;
+  rclcpp::Service<PCLTransformPointCloud>::SharedPtr
+    transform_pointcloud_service_;
+  int64_t max_transforms_;
+
+public:
+  TransformPointCloudService()
+  : rclcpp::Node("transform_point_cloud_service"),
+    tf_buffer_(get_clock()), tf_listener_(tf_buffer_)
+  {
+    // -1 signals an infinite number of attempts
+    // If a value is set to above this, it should probably be -1
+    constexpr int64_t MAX_REASONABLE_TRANSFORM_ATTEMPTS = 500;
+
+    // Setup ROS parameters
+    rcl_interfaces::msg::ParameterDescriptor param_constraints;
+    rcl_interfaces::msg::IntegerRange integer_range;
+
+    integer_range.from_value = -1;
+    integer_range.to_value = MAX_REASONABLE_TRANSFORM_ATTEMPTS;
+    param_constraints.integer_range.push_back(integer_range);
+
+    max_transforms_ = declare_parameter<int64_t>(
+      "max_transform_attempts", std::move(param_constraints));
+
+    // Attach the callback
+    auto callback = std::bind(
+      &TransformPointCloudService::transformm_point_cloud,
+      this, std::placeholders::_1, std::placeholders::_2);
+
+    transform_pointcloud_service_ = create_service<PCLTransformPointCloud>(
+      "transform_point_cloud", std::move(callback));
+  }
+
+  /**
+   * Transform an array of PointCloud2 into a single PointCloud2.
+   *
+   * Given an array of PointCloud2 messages, transform into a single PointCloud2
+   * message.
+   *
+   * @param[in] req sensor_msgs/PointCloud2 Container of PointCloud2 messages.
+   * @param[out] res sensor_msgs/PointCloud2 A PointCloud2 message.
+   * @return Bool Service completion result.
+   */
+  bool transformm_point_cloud(
+    PCLTransformPointCloud::Request::SharedPtr req,
+    PCLTransformPointCloud::Response::SharedPtr res)
+  {
+    get_parameter<int64_t>("max_transform_attempts", max_transforms_);
+
+    geometry_msgs::msg::TransformStamped transform;
+    bool got_transform = false;
+
+    // if the user picks -1, it will attempt a near infinite amount of times
+    for (int64_t runs = 0; runs < max_transforms_; runs++) {
+      try {
+        transform = tf_buffer_.lookupTransform(
+          req->target_frame, req->cloud_in.header.frame_id, tf2::TimePointZero);
+
+        got_transform = true;
+        break;
+      } catch (const tf2::TransformException &) {}
+    }
+
+    if (!got_transform) {
+      RCLCPP_ERROR(
+        get_logger(), "No transform recieved from %s to %s",
+        req->target_frame.c_str(), req->cloud_in.header.frame_id.c_str());
+
+      return false;
+    }
+
+    tf2::doTransform(req->cloud_in, res->cloud_out, transform);
+
+    return true;
+  }
+};
+
+int main(int argc, char ** argv)
+{
+  rclcpp::init(argc, argv);
+  auto node = std::make_shared<TransformPointCloudService>();
+  rclcpp::spin(node);
+  rclcpp::shutdown();
+
+  return 0;
+}

--- a/pcl_utilities/src/transform_point_cloud_service.cpp
+++ b/pcl_utilities/src/transform_point_cloud_service.cpp
@@ -15,12 +15,9 @@
  *    `ros2 launch pcl_utilities transform_point_cloud.xml`
  */
 
-#include <cstdint>  // std::int64_t
-#include <functional>  // std::bind
-#include <iomanip>  // std::quoted
+#include <cstdint>  // int64_t
+#include <functional>  // std::bind, std::placeholders
 #include <memory>  // std::make_shared
-#include <sstream>  // std::stringstream
-#include <string>
 #include <utility>  // std::move
 
 #include "pcl_utility_msgs/srv/pcl_transform_point_cloud.hpp"

--- a/pcl_utility_msgs/CMakeLists.txt
+++ b/pcl_utility_msgs/CMakeLists.txt
@@ -26,6 +26,7 @@ find_package(rosidl_default_generators REQUIRED)
 rosidl_generate_interfaces(${PROJECT_NAME}
   "srv/PCLVoxelGridFilter.srv"
   "srv/PCLConcatenatePointCloud.srv"
+  "srv/PCLTransformPointCloud.srv"
   DEPENDENCIES sensor_msgs
 )
 

--- a/pcl_utility_msgs/srv/PCLTransformPointCloud.srv
+++ b/pcl_utility_msgs/srv/PCLTransformPointCloud.srv
@@ -1,0 +1,4 @@
+string target_frame
+sensor_msgs/PointCloud2 cloud_in
+---
+sensor_msgs/PointCloud2 cloud_out


### PR DESCRIPTION
# Changes
## transform_point_cloud_service:
- Inlined the function `getFrameTransform`.
- Converted camel to snake case.
- Rmmoved test/debugging print statements.
- Added parameter for the max number of runs.
## simple_test_transform_point_cloud:
- Publish a custom TF frame and transform.
- Set a source frame from the launch file.
- Call the service and publish the result.
- No tests were added since this testing strategy will be changed later.
## CMakeLists.txt/Package.xml
- Add missing dependencies.

# Working Code
![transform_point_cloud_works_1](https://github.com/user-attachments/assets/8d8ce5ca-66db-4ea0-afdd-c681ee11819e)
![transform_pointcloud_works_2](https://github.com/user-attachments/assets/c4d2fbb3-03ad-42da-b537-e6796c4d0e51)

The two point cloud images overlap, so it only looks like one is present. The second image shows that the tf frame of the transformed point cloud is different.
