### PR TITLE
Port Euclidean Cluster Extraction to ROS2

### DIFF
--- a/pcl_utilities/CMakeLists.txt
+++ b/pcl_utilities/CMakeLists.txt
@@ -35,7 +35,6 @@ if((CMAKE_CXX_COMPILER_ID STREQUAL "Clang" AND
   endif()
 endif()
 
-find_package(PCL REQUIRED)
 # PCL may fail to link with certain environments where
 # `PCL_ROOT` becomes set to '/'.
 # See: https://github.com/PointCloudLibrary/pcl/issues/4661
@@ -48,18 +47,22 @@ find_package(PCL REQUIRED)
 # set(PCL_DIR /usr/lib/x86_64-linux-gnu/cmake/pcl)
 
 find_package(ament_cmake REQUIRED)
-find_package(sensor_msgs REQUIRED)
-find_package(pcl_utility_msgs REQUIRED)
-find_package(pcl_ros REQUIRED)
+find_package(PCL REQUIRED)
 find_package(pcl_conversions REQUIRED)
+find_package(pcl_ros REQUIRED)
+find_package(pcl_utility_msgs REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(rcl_interfaces REQUIRED)
+find_package(sensor_msgs REQUIRED)
 
 set(THIS_PACKAGE_DEPS
-  rclcpp
-  sensor_msgs
-  pcl_ros
-  pcl_conversions
-  pcl_utility_msgs
   PCL
+  pcl_conversions
+  pcl_ros
+  pcl_utility_msgs
+  rclcpp
+  rcl_interfaces
+  sensor_msgs
 )
 
 include_directories(${PCL_INCLUDE_DIRS})
@@ -71,12 +74,16 @@ add_library(${PROJECT_NAME} INTERFACE)
 
 add_executable(voxel_grid_filter_service src/voxel_grid_filter_service.cpp)
 add_executable(concatenate_point_cloud_service src/concatenate_point_cloud_service.cpp)
+add_executable(euclidean_cluster_extraction_service src/euclidean_cluster_extraction_service.cpp)
+
 ament_target_dependencies(voxel_grid_filter_service ${THIS_PACKAGE_DEPS})
 ament_target_dependencies(concatenate_point_cloud_service ${THIS_PACKAGE_DEPS})
+ament_target_dependencies(euclidean_cluster_extraction_service ${THIS_PACKAGE_DEPS})
 
 set(THIS_PACKAGE_EXECS
   voxel_grid_filter_service
   concatenate_point_cloud_service
+  euclidean_cluster_extraction_service
 )
 
 if(BUILD_TESTING)
@@ -97,8 +104,8 @@ if(BUILD_TESTING)
   set(
     THIS_PACKAGE_TEST_DEPS
     rclcpp
+    rcl_interfaces
     sensor_msgs
-    pcl_ros
     pcl_utility_msgs
   )
 

--- a/pcl_utilities/CMakeLists.txt
+++ b/pcl_utilities/CMakeLists.txt
@@ -9,7 +9,6 @@ project(pcl_utilities)
 #
 # It is the users responsibility to add the appropriate flags on
 # non Clang/GNU-based compilers (including. non-posix frontend variants.)
-
 if(NOT CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 17)
 endif()
@@ -57,8 +56,8 @@ endif()
 # Fix by setting PCL_DIR to the path of the PCL cmake file:
 # set(PCL_DIR /usr/lib/x86_64-linux-gnu/cmake/pcl)
 
-find_package(Eigen3 REQUIRED NO_MODULE)
 find_package(ament_cmake REQUIRED)
+find_package(Eigen3 REQUIRED NO_MODULE)
 find_package(PCL REQUIRED)
 find_package(pcl_conversions REQUIRED)
 find_package(pcl_ros REQUIRED)
@@ -86,21 +85,21 @@ add_definitions(${PCL_DEFINITIONS} -DPCL_NO_PRECOMPILE)
 # build all files
 add_library(${PROJECT_NAME} INTERFACE)
 
-add_executable(voxel_grid_filter_service src/voxel_grid_filter_service.cpp)
 add_executable(concatenate_point_cloud_service src/concatenate_point_cloud_service.cpp)
 add_executable(euclidean_cluster_extraction_service src/euclidean_cluster_extraction_service.cpp)
 add_executable(passthrough_filter_service src/passthrough_filter_service.cpp)
+add_executable(voxel_grid_filter_service src/voxel_grid_filter_service.cpp)
 
-ament_target_dependencies(voxel_grid_filter_service ${THIS_PACKAGE_DEPS})
 ament_target_dependencies(concatenate_point_cloud_service ${THIS_PACKAGE_DEPS})
 ament_target_dependencies(euclidean_cluster_extraction_service ${THIS_PACKAGE_DEPS})
 ament_target_dependencies(passthrough_filter_service ${THIS_PACKAGE_DEPS})
+ament_target_dependencies(voxel_grid_filter_service ${THIS_PACKAGE_DEPS})
 
 set(THIS_PACKAGE_EXECS
-  voxel_grid_filter_service
   concatenate_point_cloud_service
   euclidean_cluster_extraction_service
   passthrough_filter_service
+  voxel_grid_filter_service
 )
 
 if(BUILD_TESTING)
@@ -112,35 +111,35 @@ if(BUILD_TESTING)
     PCL
     pcl_conversions
     pcl_ros
+    pcl_utility_msgs
     rclcpp
     rcl_interfaces
-    rcl_interfaces
     sensor_msgs
-    pcl_utility_msgs
   )
 
-  add_executable(simple_test_voxel_grid_filter src/tests/simple_test_voxel_grid_filter.cpp)
   add_executable(simple_test_concatenate_point_cloud src/tests/simple_test_concatenate_point_cloud.cpp)
   add_executable(simple_test_euclidean_cluster_extraction src/tests/simple_test_euclidean_cluster_extraction.cpp)
   add_executable(simple_test_passthrough_filter src/tests/simple_test_passthrough_filter.cpp)
+  add_executable(simple_test_voxel_grid_filter src/tests/simple_test_voxel_grid_filter.cpp)
 
-  ament_target_dependencies(simple_test_voxel_grid_filter ${THIS_PACKAGE_TEST_DEPS})
   ament_target_dependencies(simple_test_concatenate_point_cloud ${THIS_PACKAGE_TEST_DEPS})
   ament_target_dependencies(simple_test_euclidean_cluster_extraction ${THIS_PACKAGE_TEST_DEPS})
   ament_target_dependencies(simple_test_passthrough_filter ${THIS_PACKAGE_TEST_DEPS})
+  ament_target_dependencies(simple_test_voxel_grid_filter ${THIS_PACKAGE_TEST_DEPS})
 
   list(APPEND THIS_PACKAGE_EXECS
-    simple_test_voxel_grid_filter
     simple_test_concatenate_point_cloud
     simple_test_passthrough_filter
     simple_test_euclidean_cluster_extraction
+    simple_test_voxel_grid_filter
   )
 
   if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     # these options will make debugging memory issues and undefined behavior easier
     # -g3 -O0 : make debugging easier using GDB
-    # -D FORTIFY_SOURCE=2 : adds memory corruption protections
-    add_compile_options(-g3 -O0 -D FORTIFY_SOURCE=2)
+    # -D _FORTIFY_SOURCE=2 : adds memory corruption protections
+    add_definitions(-D_FORTIFY_SOURCE=2)
+    add_compile_options(-g3 -O0)
 
     # Need to remove `-Wpedantic` since PCL uses constructs that are not
     # Standard compliant which produces warnings under `pedantic`

--- a/pcl_utilities/CMakeLists.txt
+++ b/pcl_utilities/CMakeLists.txt
@@ -72,7 +72,7 @@ include_directories(${PCL_INCLUDE_DIRS})
 link_directories(${PCL_LIBRARY_DIRS})
 # PCL_NO_PRECOMPILE is required to avoid address sanitizer issues in clang,
 # see https://github.com/PointCloudLibrary/pcl/issues/5831
-add_definitions(${PCL_DEFINITIONS} PCL_NO_PRECOMPILE)
+add_definitions(${PCL_DEFINITIONS} -DPCL_NO_PRECOMPILE)
 
 # build all files
 add_library(${PROJECT_NAME} INTERFACE)

--- a/pcl_utilities/CMakeLists.txt
+++ b/pcl_utilities/CMakeLists.txt
@@ -37,11 +37,6 @@ if((CMAKE_CXX_COMPILER_ID STREQUAL "Clang" AND
   endif()
 endif()
 
-# add_compile_definitions(${PCL_DEFINITIONS})
-# PCL_NO_PRECOMPILE is required to avoid address sanitizer issues in clang, see https://github.com/PointCloudLibrary/pcl/issues/5831
-# add_compile_definitions(PCL_NO_PRECOMPILE)
-add_link_options(-fsanitize=undefined,address,leak)
-add_compile_options(-fsanitize=undefined,address,leak)
 # PCL may fail to link with certain environments where
 # `PCL_ROOT` becomes set to '/'.
 # See: https://github.com/PointCloudLibrary/pcl/issues/4661
@@ -75,7 +70,9 @@ set(THIS_PACKAGE_DEPS
 
 include_directories(${PCL_INCLUDE_DIRS})
 link_directories(${PCL_LIBRARY_DIRS})
-add_definitions(${PCL_DEFINITIONS})
+# PCL_NO_PRECOMPILE is required to avoid address sanitizer issues in clang,
+# see https://github.com/PointCloudLibrary/pcl/issues/5831
+add_definitions(${PCL_DEFINITIONS} PCL_NO_PRECOMPILE)
 
 # build all files
 add_library(${PROJECT_NAME} INTERFACE)

--- a/pcl_utilities/CMakeLists.txt
+++ b/pcl_utilities/CMakeLists.txt
@@ -7,20 +7,22 @@ endif()
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   # disable the error message associated with VLAs for now until changed
-  add_compile_options(-Wall -Wextra -Wpedantic) # -Werror
+  # -Werror flag is removed due to errors involving redundent syntax,
+  # anonymous structs/unions in pcl/point_types.h
+  add_compile_options(-Wall -Wextra -pedantic) # -Werror
 endif()
 
-# This is a workaround for a issue within Clang based compilers and BOOST MPL.
-# BOOST MPL invokes undefined behavior by casting an integer to an enum
-# value that does not exist. PCL uses Boost MPL so many header files do not
-# compile. This should be fixed in the next release of Boost, version 1.86.0
+# This is a workaround for a issue that existed within Clang based
+# compilers and BOOST MPL. BOOST MPL invoked undefined behavior by
+# casting an integer to an enum value that does not exist. PCL uses
+# Boost MPL so many header files do not compile. This bug was patched
+# in Boost 1.86.0.
 #
 # Clang failed to diagnose the issue until at least version 16.0.0
 # after which it was a error. This detects the issue and opts out of the check
 #
-# NOTE: Compiler's that use Clang internally but that use different versioning
-# always apply the flag do to a lack of documentation. A warning may occur about an
-# additional compile option.
+# NOTE: Compiler's that use LLVM/Clang internally but that use a different
+# versioning schemes always have the flag applied.
 #
 # All Clang based compilers should match the regex, based on input from:
 # https://cmake.org/cmake/help/latest/variable/CMAKE_LANG_COMPILER_ID.html
@@ -35,6 +37,11 @@ if((CMAKE_CXX_COMPILER_ID STREQUAL "Clang" AND
   endif()
 endif()
 
+# add_compile_definitions(${PCL_DEFINITIONS})
+# PCL_NO_PRECOMPILE is required to avoid address sanitizer issues in clang, see https://github.com/PointCloudLibrary/pcl/issues/5831
+# add_compile_definitions(PCL_NO_PRECOMPILE)
+add_link_options(-fsanitize=undefined,address,leak)
+add_compile_options(-fsanitize=undefined,address,leak)
 # PCL may fail to link with certain environments where
 # `PCL_ROOT` becomes set to '/'.
 # See: https://github.com/PointCloudLibrary/pcl/issues/4661
@@ -46,6 +53,7 @@ endif()
 # Fix by setting PCL_DIR to the path of the PCL cmake file:
 # set(PCL_DIR /usr/lib/x86_64-linux-gnu/cmake/pcl)
 
+find_package(Eigen3 REQUIRED NO_MODULE)
 find_package(ament_cmake REQUIRED)
 find_package(PCL REQUIRED)
 find_package(pcl_conversions REQUIRED)
@@ -90,19 +98,11 @@ if(BUILD_TESTING)
   # All testing and visualization files are not produced if not in
   # BUILT_TESTING. Launch files will still exist but will fail to launch nodes
 
-  if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-    # these options will make debugging memory issues and undefined behavior easier
-    # -g3 -O0 : make debugging easier using GDB
-    # -fstack-protector-all : will crash if stack corruption is detected
-    # -D FORTIFY_SOURCE=2 : adds memory corruption protections
-    # -ftrapv : detects signed overflow which is undefined per the C++ standard
-    # -Wl,-z,relro : a linker flag to move immutable memory into ROM which
-    #     will help detect invalid writes
-    add_compile_options(-g3 -O0 -D FORTIFY_SOURCE=2)
-  endif()
-
-  set(
-    THIS_PACKAGE_TEST_DEPS
+  set(THIS_PACKAGE_TEST_DEPS
+    Eigen3
+    PCL
+    pcl_conversions
+    pcl_ros
     rclcpp
     rcl_interfaces
     sensor_msgs
@@ -111,14 +111,31 @@ if(BUILD_TESTING)
 
   add_executable(simple_test_voxel_grid_filter src/tests/simple_test_voxel_grid_filter.cpp)
   add_executable(simple_test_concatenate_point_cloud src/tests/simple_test_concatenate_point_cloud.cpp)
+  add_executable(simple_test_euclidean_cluster_extraction src/tests/simple_test_euclidean_cluster_extraction.cpp)
 
   ament_target_dependencies(simple_test_voxel_grid_filter ${THIS_PACKAGE_TEST_DEPS})
   ament_target_dependencies(simple_test_concatenate_point_cloud ${THIS_PACKAGE_TEST_DEPS})
+  ament_target_dependencies(simple_test_euclidean_cluster_extraction ${THIS_PACKAGE_TEST_DEPS})
 
   list(APPEND THIS_PACKAGE_EXECS
     simple_test_voxel_grid_filter
     simple_test_concatenate_point_cloud
+    simple_test_euclidean_cluster_extraction
   )
+
+  if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    # these options will make debugging memory issues and undefined behavior easier
+    # -g3 -O0 : make debugging easier using GDB
+    # -D FORTIFY_SOURCE=2 : adds memory corruption protections
+    add_compile_options(-g3 -O0 -D FORTIFY_SOURCE=2)
+
+    # Need to remove `-Wpedantic` since PCL uses constructs that are not
+    # Standard compliant which produces warnings under `pedantic`
+    # Use `SHELL:` prefix to avoid deduplication, if `-Wno-pedantic` is added
+    # elsewhere.
+    target_compile_options(simple_test_euclidean_cluster_extraction
+      PRIVATE "SHELL:-Wno-pedantic")
+  endif()
 
   find_package(ament_lint_auto REQUIRED)
   # the following line skips the linter which checks for copyrights

--- a/pcl_utilities/launch/euclidean_cluster_extraction.xml
+++ b/pcl_utilities/launch/euclidean_cluster_extraction.xml
@@ -1,0 +1,13 @@
+<launch>
+    <node
+        pkg="pcl_utilities"
+        exec="euclidean_cluster_extraction_service"
+        name="euclidean_cluster_extraction"
+        namespace="robot_common_3d/pcl_utilities"
+        output="screen"
+    >
+      <param name="filters.euclidean_cluster_extraction.cluster_tolerance" value="0.02" />
+      <param name="filters.euclidean_cluster_extraction.min_cluster_size" value="100" />
+      <param name="filters.euclidean_cluster_extraction.max_cluster_size" value="25000" />
+    </node>
+</launch>

--- a/pcl_utilities/launch/tests/test_euclidean_cluster_extraction.xml
+++ b/pcl_utilities/launch/tests/test_euclidean_cluster_extraction.xml
@@ -1,0 +1,29 @@
+<launch>
+    <!--
+        Pointcloud is published to the topic: tests/robot_common_3d/pcl_utilities/euclidean_cluster_extraction/cloud_filtered
+
+        Must launch camera with depth output enabled before this node and
+        specify the ros arg `-\-ros-args point_cloud_topic:=<topic>`
+        example:
+
+        ```
+        ros2 launch realsense2_camera rs_launch.py depth_module.depth_profile:=1280x720x30 pointcloud.enable:=true
+
+        ros2 launch pcl_utilities test_euclidean_cluster_extraction.xml point_cloud_topic:=/camera/camera/depth/color/points
+        ```
+    -->
+
+    <arg name="point_cloud_topic" />
+    <arg name="num_point_clouds" default="5" />
+    <include file="$(find-pkg-share pcl_utilities)/launch/euclidean_cluster_extraction.xml" />
+    <node
+        pkg="pcl_utilities"
+        exec="simple_test_euclidean_cluster_extraction"
+        name="simple_test_euclidean_cluster_extraction"
+        namespace="/tests/robot_common_3d/pcl_utilities"
+        output="screen"
+    >
+        <param name="node_client_name" value="/robot_common_3d/pcl_utilities/euclidean_cluster_extraction" />
+        <param name="point_cloud_topic" value="$(var point_cloud_topic)" />
+    </node>
+</launch>

--- a/pcl_utilities/package.xml
+++ b/pcl_utilities/package.xml
@@ -9,9 +9,13 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
-  <depend>rclcpp</depend>
-  <depend>sensor_msgs</depend>
+  <depend>pcl</depend>
+  <depend>pcl_conversions</depend>
+  <depend>pcl_ros</depend>
   <depend>pcl_utility_msgs</depend>
+  <depend>rclcpp</depend>
+  <depend>rcl_interfaces</depend>
+  <depend>sensor_msgs</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/pcl_utilities/src/euclidean_cluster_extraction_service.cpp
+++ b/pcl_utilities/src/euclidean_cluster_extraction_service.cpp
@@ -1,0 +1,170 @@
+/*
+ * Author: Brian Flynn
+ * Date: Nov 15, 2022
+ * Editors: Christian Tagliamonte
+ * Last Modified: Aug 4, 2024
+ * Adapted from:
+ * https://github.com/uml-robotics/armada_behaviors/blob/main/armada_flexbe_utilities/src/service/pcl_concatenate_pointcloud_service.cpp
+ *
+ * Description: Starts up a service for concatenating point cloud messages.
+ *
+ * Input: sensor_msgs/PointCloud2[]
+ * Output: sensor_msgs/PointCloud2
+ *
+ * Usage:
+ *    `ros2 launch pcl_utilities concatenate_point_cloud.xml`
+ */
+#include <cassert>  // assert
+#include <functional>  // for std::bind
+#include <limits>  // std::numeric_limits
+#include <memory>  // std::make_shared
+#include <string_view>
+#include <type_traits>  // std::common_type
+#include <utility>  // std::move
+#include <vector>
+
+#include "pcl/impl/point_types.hpp"
+#include "pcl/point_cloud.h"
+#include "pcl/segmentation/extract_clusters.h"
+#include "pcl_conversions/pcl_conversions.h"
+#include "pcl_utility_msgs/srv/pcl_euclidean_cluster_extraction.hpp"
+
+#include "rclcpp/node.hpp"
+#include "rclcpp/service.hpp"
+#include "rcl_interfaces/msg/integer_range.hpp"
+#include "rcl_interfaces/msg/parameter_descriptor.hpp"
+#include "sensor_msgs/msg/point_cloud2.hpp"
+
+using pcl_utility_msgs::srv::PCLEuclideanClusterExtraction;
+constexpr std::string_view g_PARAM_NAMESPACE = "filters.euclidean_cluster_extraction.";
+
+class EuclideanClusterExtractionService : public rclcpp::Node
+{
+private:
+  rclcpp::Service<PCLEuclideanClusterExtraction>::SharedPtr
+    euclidean_cluster_extraction_service_;
+  rcl_interfaces::msg::ParameterDescriptor param_constraints_;
+  double cluster_tolerance_;
+  int64_t min_cluster_size_;
+  int64_t max_cluster_size_;
+
+public:
+  /**
+   * Class Constructor.
+   *
+   * Constructor for EuclideanClusterExtractionService class.
+   */
+  EuclideanClusterExtractionService()
+  : rclcpp::Node("euclidean_cluster_extraction_service")
+  {
+    std::string param_namespace {g_PARAM_NAMESPACE};
+
+    // cap the parameter value within the range of pcl::uindex_t
+    rcl_interfaces::msg::IntegerRange integer_range;
+    using RangeType = std::common_type_t<int64_t, pcl::uindex_t>;
+    auto value_or_max = std::min<RangeType>(
+      std::numeric_limits<int64_t>::max(),
+      std::numeric_limits<pcl::uindex_t>::max());
+
+    integer_range.from_value = 0;
+    integer_range.to_value = static_cast<int64_t>(value_or_max);
+    param_constraints_.integer_range.push_back(integer_range);
+
+    // declare all parameters
+    cluster_tolerance_ = declare_parameter<double>(
+      param_namespace + "cluster_tolerance");
+
+    min_cluster_size_ = declare_parameter<int64_t>(
+      param_namespace + "min_cluster_size", param_constraints_);
+    max_cluster_size_ = declare_parameter<int64_t>(
+      param_namespace + "max_cluster_size", param_constraints_);
+
+    // create callback and setup service
+    auto callback = std::bind(
+      &EuclideanClusterExtractionService::euclidean_cluster_extraction,
+      this, std::placeholders::_1, std::placeholders::_2);
+
+    euclidean_cluster_extraction_service_ = create_service<PCLEuclideanClusterExtraction>(
+      "euclidean_cluster_extraction", std::move(callback));
+  }
+
+  /**
+   * Segment clusters within a PointCloud into individual cloud objects.
+   *
+   * BGiven a PointCloud2 message, segment clusters of points into their 
+   * own PointCloud2 objects for further processing/handling.
+   *
+   * @param[in] req sensor_msgs/PointCloud2 A PointCloud2 message.
+   * @param[out] res sensor_msgs/PointCloud2 A PointCloud2 message.
+   * @return Bool Service completion result.
+   */
+  bool euclidean_cluster_extraction(
+    PCLEuclideanClusterExtraction::Request::SharedPtr req,
+    PCLEuclideanClusterExtraction::Response::SharedPtr res)
+  {
+    std::string param_namespace {g_PARAM_NAMESPACE};
+
+    get_parameter(param_namespace + "cluster_tolerance", cluster_tolerance_);
+    get_parameter(param_namespace + "min_cluster_size", min_cluster_size_);
+    get_parameter(param_namespace + "max_cluster_size", max_cluster_size_);
+
+    auto input_cloud = std::make_shared<pcl::PointCloud<pcl::PointXYZRGB>>();
+    sensor_msgs::msg::PointCloud2 temp_cloud;
+    std::vector<sensor_msgs::msg::PointCloud2> obstacle_cloud_list_out;
+
+    pcl::moveFromROSMsg(req->cloud_in, *input_cloud);
+
+    auto tree = std::make_shared<pcl::search::KdTree<pcl::PointXYZRGB>>();
+    tree->setInputCloud(input_cloud);
+
+    pcl::EuclideanClusterExtraction<pcl::PointXYZRGB> ec;
+    std::vector<pcl::PointIndices> cluster_indices;
+
+    ec.setClusterTolerance(cluster_tolerance_);
+    ec.setMinClusterSize(static_cast<pcl::uindex_t>(min_cluster_size_));
+    ec.setMaxClusterSize(static_cast<pcl::uindex_t>(max_cluster_size_));
+    ec.setSearchMethod(tree);
+    ec.setInputCloud(input_cloud);
+    ec.extract(cluster_indices);
+
+    for (const pcl::PointIndices& indecies : cluster_indices) {
+      pcl::PointCloud<pcl::PointXYZRGB> cloud_cluster;
+
+      for (pcl::index_t index : indecies.indices) {
+        assert(index >= 0 && index <= std::numeric_limits<size_t>::max());
+
+        cloud_cluster.push_back((*input_cloud)[static_cast<size_t>(index)]);
+      }
+
+      assert(cloud_cluster.size() <= std::numeric_limits<pcl::uindex_t>::max());
+
+      cloud_cluster.width = static_cast<pcl::uindex_t>(cloud_cluster.size());
+      cloud_cluster.height = 1U;
+      cloud_cluster.is_dense = true;
+      cloud_cluster.header.frame_id = input_cloud->header.frame_id;
+
+      pcl::toROSMsg(cloud_cluster, temp_cloud);
+      obstacle_cloud_list_out.push_back(std::move(temp_cloud));
+    }
+
+    if (obstacle_cloud_list_out.empty()) {
+      return true;
+    }
+
+    res->target_cloud_out = std::move(obstacle_cloud_list_out[0]);
+    obstacle_cloud_list_out.erase(obstacle_cloud_list_out.cbegin());
+
+    res->obstacle_cloud_list_out = std::move(obstacle_cloud_list_out);
+    return true;
+  }
+};
+
+int main(int argc, char ** argv)
+{
+  rclcpp::init(argc, argv);
+  auto node = std::make_shared<EuclideanClusterExtractionService>();
+  rclcpp::spin(node);
+  rclcpp::shutdown();
+
+  return 0;
+}

--- a/pcl_utilities/src/euclidean_cluster_extraction_service.cpp
+++ b/pcl_utilities/src/euclidean_cluster_extraction_service.cpp
@@ -2,28 +2,30 @@
  * Author: Brian Flynn
  * Date: Nov 15, 2022
  * Editors: Christian Tagliamonte
- * Last Modified: Aug 4, 2024
+ * Last Modified: Jan 2, 2025
  * Adapted from:
  * https://github.com/uml-robotics/armada_behaviors/blob/main/armada_flexbe_utilities/src/service/pcl_concatenate_pointcloud_service.cpp
  *
- * Description: Starts up a service for concatenating point cloud messages.
+ * Description: Starts up a service for extracting point clusters
+ *   from an input point cloud message. Thus script returns a list of
+ *   individual point cloud messages for each identified cluster.
  *
- * Input: sensor_msgs/PointCloud2[]
- * Output: sensor_msgs/PointCloud2
+ * Input: sensor_msgs/PointCloud2
+ * Output: sensor_msgs/PointCloud2[]
  *
  * Usage:
  *    `ros2 launch pcl_utilities concatenate_point_cloud.xml`
  */
 #include <cassert>  // assert
+#include <cstdint>  // uintmax_t
 #include <functional>  // for std::bind
 #include <limits>  // std::numeric_limits
 #include <memory>  // std::make_shared
-#include <string_view>
-#include <type_traits>  // std::common_type
+#include <string_view>  // std::string_view
 #include <utility>  // std::move
-#include <vector>
+#include <vector>  // std::string
 
-#include "pcl/impl/point_types.hpp"
+#include "pcl/point_types.h"
 #include "pcl/point_cloud.h"
 #include "pcl/segmentation/extract_clusters.h"
 #include "pcl_conversions/pcl_conversions.h"
@@ -36,8 +38,10 @@
 #include "sensor_msgs/msg/point_cloud2.hpp"
 
 using pcl_utility_msgs::srv::PCLEuclideanClusterExtraction;
-constexpr std::string_view g_PARAM_NAMESPACE = "filters.euclidean_cluster_extraction.";
+constexpr std::string_view kParamNamespaceView = "filters.euclidean_cluster_extraction.";
 
+namespace
+{
 class EuclideanClusterExtractionService : public rclcpp::Node
 {
 private:
@@ -57,13 +61,12 @@ public:
   EuclideanClusterExtractionService()
   : rclcpp::Node("euclidean_cluster_extraction_service")
   {
-    std::string param_namespace {g_PARAM_NAMESPACE};
+    const std::string kParamNamespace {kParamNamespaceView};
 
     // cap the parameter value within the range of pcl::uindex_t
     rcl_interfaces::msg::IntegerRange integer_range;
-    using RangeType = std::common_type_t<int64_t, pcl::uindex_t>;
-    auto value_or_max = std::min<RangeType>(
-      std::numeric_limits<int64_t>::max(),
+    auto value_or_max = std::min<uintmax_t>(
+      static_cast<uintmax_t>(std::numeric_limits<int64_t>::max()),
       std::numeric_limits<pcl::uindex_t>::max());
 
     integer_range.from_value = 0;
@@ -72,12 +75,12 @@ public:
 
     // declare all parameters
     cluster_tolerance_ = declare_parameter<double>(
-      param_namespace + "cluster_tolerance");
+      kParamNamespace + "cluster_tolerance");
 
     min_cluster_size_ = declare_parameter<int64_t>(
-      param_namespace + "min_cluster_size", param_constraints_);
+      kParamNamespace + "min_cluster_size", param_constraints_);
     max_cluster_size_ = declare_parameter<int64_t>(
-      param_namespace + "max_cluster_size", param_constraints_);
+      kParamNamespace + "max_cluster_size", param_constraints_);
 
     // create callback and setup service
     auto callback = std::bind(
@@ -91,7 +94,7 @@ public:
   /**
    * Segment clusters within a PointCloud into individual cloud objects.
    *
-   * BGiven a PointCloud2 message, segment clusters of points into their 
+   * Given a PointCloud2 message, segment clusters of points into their
    * own PointCloud2 objects for further processing/handling.
    *
    * @param[in] req sensor_msgs/PointCloud2 A PointCloud2 message.
@@ -102,11 +105,11 @@ public:
     PCLEuclideanClusterExtraction::Request::SharedPtr req,
     PCLEuclideanClusterExtraction::Response::SharedPtr res)
   {
-    std::string param_namespace {g_PARAM_NAMESPACE};
+    const std::string kParamNamespace {kParamNamespaceView};
 
-    get_parameter(param_namespace + "cluster_tolerance", cluster_tolerance_);
-    get_parameter(param_namespace + "min_cluster_size", min_cluster_size_);
-    get_parameter(param_namespace + "max_cluster_size", max_cluster_size_);
+    get_parameter(kParamNamespace + "cluster_tolerance", cluster_tolerance_);
+    get_parameter(kParamNamespace + "min_cluster_size", min_cluster_size_);
+    get_parameter(kParamNamespace + "max_cluster_size", max_cluster_size_);
 
     auto input_cloud = std::make_shared<pcl::PointCloud<pcl::PointXYZRGB>>();
     sensor_msgs::msg::PointCloud2 temp_cloud;
@@ -127,16 +130,24 @@ public:
     ec.setInputCloud(input_cloud);
     ec.extract(cluster_indices);
 
-    for (const pcl::PointIndices& indecies : cluster_indices) {
-      pcl::PointCloud<pcl::PointXYZRGB> cloud_cluster;
+    pcl::PointCloud<pcl::PointXYZRGB> cloud_cluster;
+
+    for (const pcl::PointIndices & indecies : cluster_indices) {
+      cloud_cluster.clear();
 
       for (pcl::index_t index : indecies.indices) {
-        assert(index >= 0 && index <= std::numeric_limits<size_t>::max());
+        // This should always be true, this will become relevent
+        // if PCL extends the underlying pcl::index_t type to 64 bits
+        assert(
+          index >= 0 &&
+          static_cast<uintmax_t>(index) <= uintmax_t{std::numeric_limits<size_t>::max()});
 
         cloud_cluster.push_back((*input_cloud)[static_cast<size_t>(index)]);
       }
 
-      assert(cloud_cluster.size() <= std::numeric_limits<pcl::uindex_t>::max());
+      assert(
+        uintmax_t{cloud_cluster.size()} <=
+        uintmax_t{std::numeric_limits<pcl::uindex_t>::max()});
 
       cloud_cluster.width = static_cast<pcl::uindex_t>(cloud_cluster.size());
       cloud_cluster.height = 1U;
@@ -144,20 +155,13 @@ public:
       cloud_cluster.header.frame_id = input_cloud->header.frame_id;
 
       pcl::toROSMsg(cloud_cluster, temp_cloud);
-      obstacle_cloud_list_out.push_back(std::move(temp_cloud));
+      res->cloud_list_out.push_back(std::move(temp_cloud));
     }
 
-    if (obstacle_cloud_list_out.empty()) {
-      return true;
-    }
-
-    res->target_cloud_out = std::move(obstacle_cloud_list_out[0]);
-    obstacle_cloud_list_out.erase(obstacle_cloud_list_out.cbegin());
-
-    res->obstacle_cloud_list_out = std::move(obstacle_cloud_list_out);
     return true;
   }
 };
+}  // namespace
 
 int main(int argc, char ** argv)
 {

--- a/pcl_utilities/src/euclidean_cluster_extraction_service.cpp
+++ b/pcl_utilities/src/euclidean_cluster_extraction_service.cpp
@@ -29,13 +29,14 @@
 #include "pcl/point_cloud.h"
 #include "pcl/segmentation/extract_clusters.h"
 #include "pcl_conversions/pcl_conversions.h"
-#include "pcl_utility_msgs/srv/pcl_euclidean_cluster_extraction.hpp"
 
 #include "rclcpp/node.hpp"
 #include "rclcpp/service.hpp"
 #include "rcl_interfaces/msg/integer_range.hpp"
 #include "rcl_interfaces/msg/parameter_descriptor.hpp"
 #include "sensor_msgs/msg/point_cloud2.hpp"
+
+#include "pcl_utility_msgs/srv/pcl_euclidean_cluster_extraction.hpp"
 
 using pcl_utility_msgs::srv::PCLEuclideanClusterExtraction;
 constexpr std::string_view kParamNamespaceView = "filters.euclidean_cluster_extraction.";

--- a/pcl_utilities/src/euclidean_cluster_extraction_service.cpp
+++ b/pcl_utilities/src/euclidean_cluster_extraction_service.cpp
@@ -25,16 +25,16 @@
 #include <utility>  // std::move
 #include <vector>  // std::string
 
-#include "pcl/point_types.h"
-#include "pcl/point_cloud.h"
-#include "pcl/segmentation/extract_clusters.h"
-#include "pcl_conversions/pcl_conversions.h"
-
 #include "rclcpp/node.hpp"
 #include "rclcpp/service.hpp"
 #include "rcl_interfaces/msg/integer_range.hpp"
 #include "rcl_interfaces/msg/parameter_descriptor.hpp"
 #include "sensor_msgs/msg/point_cloud2.hpp"
+
+#include "pcl/point_types.h"
+#include "pcl/point_cloud.h"
+#include "pcl/segmentation/extract_clusters.h"
+#include "pcl_conversions/pcl_conversions.h"
 
 #include "pcl_utility_msgs/srv/pcl_euclidean_cluster_extraction.hpp"
 

--- a/pcl_utilities/src/tests/simple_test_euclidean_cluster_extraction.cpp
+++ b/pcl_utilities/src/tests/simple_test_euclidean_cluster_extraction.cpp
@@ -1,0 +1,135 @@
+/*
+ * Author: Christian Tagliamonte
+ * Date: Aug Aug 4, 2024
+ * Editors: N/A
+ * Last Modified: Aug 14, 2024
+ *
+ * Description: A node to test the concatenate_point_cloud_service.
+ * This node listens to a series of sequential pointcloud
+ *   messages from the topic specified by the parameter, `point_cloud_topic.`
+ * Each message is stored within a queue with a
+ *   size specified by the parameter, `num_point_clouds` (defaults to 5). When
+ *   the queue is full, all messages in are sent
+ *   to the `concatenate_point_cloud_service`.
+ *
+ * The concatenated point cloud is then published to the topic
+ *   `concatenate_point_cloud/cloud_concatenated`
+ *
+ * Usage:
+ *    `ros2 launch pcl_utilities test_concatenate_point_cloud.xml point_cloud_topic:=<POINT_CLOUD_TOPIC>`
+ */
+#include <chrono>   // std::chrono::seconds
+#include <cstddef>  // size_t
+#include <cstdint>  // int64_t
+#include <deque>
+#include <functional>  // std::bind, std::placeholders
+#include <ios>  // std::fixed, std::setprecision
+#include <memory>  // std::make_shared
+#include <sstream>  // std::stringstream
+#include <string>
+#include <utility>  // std::move
+
+#include "rclcpp/executors.hpp"
+#include "rclcpp/logger.hpp"
+#include "rclcpp/logging.hpp"
+#include "rclcpp/node.hpp"
+#include "rclcpp/publisher.hpp"
+#include "rclcpp/subscription.hpp"
+#include "rclcpp/wait_for_message.hpp"
+#include "rcl_interfaces/msg/integer_range.hpp"
+#include "rcl_interfaces/msg/parameter_descriptor.hpp"
+
+#include "sensor_msgs/msg/point_cloud2.hpp"
+
+#include "pcl_utility_msgs/srv/pcl_euclidean_cluster_extraction.hpp"
+
+using pcl_utility_msgs::srv::PCLEuclideanClusterExtraction;
+using sensor_msgs::msg::PointCloud2;
+
+constexpr std::chrono::seconds MAX_WAIT_TIME {1U};
+
+class TestConcatenatePointCloudNode : public rclcpp::Node
+{
+private:
+  rclcpp::Client<PCLConcatenatePointCloud>::SharedPtr
+    concatenate_point_cloud_client_;
+  rclcpp::Publisher<PointCloud2>::SharedPtr output_publisher_;
+  std::string camera_topic_;
+  size_t num_point_clouds_;
+
+public:
+  TestConcatenatePointCloudNode()
+  : rclcpp::Node("simple_test_concatenate_point_cloud")
+  {
+    std::string client_topic = declare_parameter<std::string>("node_client_name");
+    camera_topic_ = declare_parameter<std::string>("point_cloud_topic");
+
+    // rclcpp uses int64_t internally, use explicit cast to size_t
+    rcl_interfaces::msg::ParameterDescriptor param_constraints;
+    rcl_interfaces::msg::IntegerRange integer_range;
+    integer_range.from_value = 0U;
+    integer_range.to_value = MAX_POINT_CLOUDS;
+    param_constraints.integer_range.push_back(integer_range);
+
+    num_point_clouds_ = static_cast<size_t>(
+      declare_parameter<int64_t>("num_point_clouds", std::move(param_constraints)));
+
+    concatenate_point_cloud_client_ =
+      create_client<PCLConcatenatePointCloud>(client_topic);
+
+    output_publisher_ = create_publisher<PointCloud2>(
+      "concatenate_point_cloud/cloud_concatenated", 1);
+  }
+
+  void spin()
+  {
+    PointCloud2 point_cloud_message;
+
+    while (rclcpp::ok()) {
+      bool was_retrieved = rclcpp::wait_for_message(
+        point_cloud_message, shared_from_this(),
+        camera_topic_, MAX_WAIT_TIME);
+
+      if (!was_retrieved) {
+        RCLCPP_ERROR_STREAM(
+          get_logger(),
+          "A camera message could not be retrieved within 1 second.");
+        continue;
+      }
+
+      process_point_cloud(std::move(point_cloud_message));
+    }
+  }
+
+  void process_point_cloud(PointCloud2 && point_cloud)
+  {
+    auto request = std::make_shared<PCLConcatenatePointCloud::Request>();
+    request->cloud_in = point_cloud;
+
+    auto response_future =
+      concatenate_point_cloud_client_->async_send_request(request);
+
+    auto response_code = rclcpp::spin_until_future_complete(
+      shared_from_this(), response_future, MAX_WAIT_TIME);
+
+    if (response_code != rclcpp::FutureReturnCode::SUCCESS) {
+      RCLCPP_ERROR_STREAM(get_logger(), "Failed to recieve a response from the service");
+      return;
+    }
+
+    PCLConcatenatePointCloud::Response::SharedPtr response {
+      response_future.get()};
+    output_publisher_->publish(response->cloud_out);
+  }
+};
+
+int main(int argc, char ** argv)
+{
+  rclcpp::init(argc, argv);
+
+  auto node = std::make_shared<TestConcatenatePointCloudNode>();
+  node->spin();
+
+  rclcpp::shutdown();
+  return 0;
+}

--- a/pcl_utilities/src/tests/simple_test_euclidean_cluster_extraction.cpp
+++ b/pcl_utilities/src/tests/simple_test_euclidean_cluster_extraction.cpp
@@ -1,94 +1,102 @@
 /*
  * Author: Christian Tagliamonte
- * Date: Aug Aug 4, 2024
+ * Date: Aug 4, 2024
  * Editors: N/A
- * Last Modified: Aug 14, 2024
+ * Last Modified: Jan 2, 2025
  *
- * Description: A node to test the concatenate_point_cloud_service.
- * This node listens to a series of sequential pointcloud
- *   messages from the topic specified by the parameter, `point_cloud_topic.`
- * Each message is stored within a queue with a
- *   size specified by the parameter, `num_point_clouds` (defaults to 5). When
- *   the queue is full, all messages in are sent
- *   to the `concatenate_point_cloud_service`.
+ * Description:
+ *    This script tests the euclidean_cluster extraction service by providng
+ *    a series of downsampled point cloud messages from a camera to the service
+ *    and publishing the result to a topic. See the full description below.
  *
- * The concatenated point cloud is then published to the topic
- *   `concatenate_point_cloud/cloud_concatenated`
+ * Steps:
+ *   This script performs the following procedures in order:
+ *   1) Listen for a point cloud message from the topic specified by
+ *      the ROS parameter, `point_cloud_topic.`
+ *   2) Crop (pcl::CropBox) then downsample (pcl::VoxelGridFilter) the
+ *      point cloud to speed up the clustering algorithm.
+ *   3) Call the `euclidean_cluster_extraction_service` node with the
+ *      the point cloud. This service returns a list of clusters as
+ *      individual point clouds.
+ *   4) Give each group visually idenfifiable tint and concatenate
+ *      all groups to produce a final point cloud.
+ *   5) Publish the final point cloud to the topic,
+ *      `euclidan_cluster_extraction/cloud_concatenated`
  *
  * Usage:
- *    `ros2 launch pcl_utilities test_concatenate_point_cloud.xml point_cloud_topic:=<POINT_CLOUD_TOPIC>`
+ *    `ros2 launch pcl_utilities test_euclidan_cluster_extraction.xml point_cloud_topic:=<POINT_CLOUD_TOPIC>`
  */
-#include <chrono>   // std::chrono::seconds
+#include <pcl/point_types.h>
+#include <pcl/point_cloud.h>
+#include <pcl_conversions/pcl_conversions.h>
+#include <pcl/point_types_conversion.h>
+
+#include <algorithm>  // std::min
+#include <cassert>  // assert
+#include <chrono>  // std::chrono::seconds
 #include <cstddef>  // size_t
-#include <cstdint>  // int64_t
-#include <deque>
+#include <cstdint>  // uint8_t
 #include <functional>  // std::bind, std::placeholders
-#include <ios>  // std::fixed, std::setprecision
 #include <memory>  // std::make_shared
-#include <sstream>  // std::stringstream
-#include <string>
+#include <string>  // std::string
 #include <utility>  // std::move
 
-#include "rclcpp/executors.hpp"
-#include "rclcpp/logger.hpp"
-#include "rclcpp/logging.hpp"
-#include "rclcpp/node.hpp"
-#include "rclcpp/publisher.hpp"
-#include "rclcpp/subscription.hpp"
-#include "rclcpp/wait_for_message.hpp"
-#include "rcl_interfaces/msg/integer_range.hpp"
-#include "rcl_interfaces/msg/parameter_descriptor.hpp"
+#include <Eigen/Core>  // Eigen::Vector4f
+#include <pcl/filters/crop_box.h>
+#include <pcl/filters/voxel_grid.h>
 
-#include "sensor_msgs/msg/point_cloud2.hpp"
+#include <rclcpp/executors.hpp>
+#include <rclcpp/logger.hpp>
+#include <rclcpp/logging.hpp>
+#include <rclcpp/node.hpp>
+#include <rclcpp/publisher.hpp>
+#include <rclcpp/subscription.hpp>
+#include <rclcpp/wait_for_message.hpp>
 
+#include <pcl/pcl_config.h>
+
+#include <sensor_msgs/msg/point_cloud2.hpp>
 #include "pcl_utility_msgs/srv/pcl_euclidean_cluster_extraction.hpp"
 
 using pcl_utility_msgs::srv::PCLEuclideanClusterExtraction;
-using sensor_msgs::msg::PointCloud2;
+using ROSPointCloud2 = sensor_msgs::msg::PointCloud2;
 
-constexpr std::chrono::seconds MAX_WAIT_TIME {1U};
+namespace
+{
+constexpr std::chrono::seconds kMaxWaitTime {5U};
+float lerp_float(float first, float second, float factor);
 
-class TestConcatenatePointCloudNode : public rclcpp::Node
+class TestEuclidanClusterExtractionNode : public rclcpp::Node
 {
 private:
-  rclcpp::Client<PCLConcatenatePointCloud>::SharedPtr
-    concatenate_point_cloud_client_;
-  rclcpp::Publisher<PointCloud2>::SharedPtr output_publisher_;
+  rclcpp::Client<PCLEuclideanClusterExtraction>::SharedPtr
+    euclidan_cluster_extraction_client_;
+  rclcpp::Publisher<ROSPointCloud2>::SharedPtr output_publisher_;
   std::string camera_topic_;
-  size_t num_point_clouds_;
 
 public:
-  TestConcatenatePointCloudNode()
-  : rclcpp::Node("simple_test_concatenate_point_cloud")
+  TestEuclidanClusterExtractionNode()
+  : rclcpp::Node("simple_test_euclidan_cluster_extraction")
   {
-    std::string client_topic = declare_parameter<std::string>("node_client_name");
+    std::string client_topic = declare_parameter<std::string>(
+      "node_client_name");
     camera_topic_ = declare_parameter<std::string>("point_cloud_topic");
 
-    // rclcpp uses int64_t internally, use explicit cast to size_t
-    rcl_interfaces::msg::ParameterDescriptor param_constraints;
-    rcl_interfaces::msg::IntegerRange integer_range;
-    integer_range.from_value = 0U;
-    integer_range.to_value = MAX_POINT_CLOUDS;
-    param_constraints.integer_range.push_back(integer_range);
+    euclidan_cluster_extraction_client_ =
+      create_client<PCLEuclideanClusterExtraction>(client_topic);
 
-    num_point_clouds_ = static_cast<size_t>(
-      declare_parameter<int64_t>("num_point_clouds", std::move(param_constraints)));
-
-    concatenate_point_cloud_client_ =
-      create_client<PCLConcatenatePointCloud>(client_topic);
-
-    output_publisher_ = create_publisher<PointCloud2>(
-      "concatenate_point_cloud/cloud_concatenated", 1);
+    output_publisher_ = create_publisher<ROSPointCloud2>(
+      "euclidan_cluster_extraction/clusters", 1);
   }
 
   void spin()
   {
-    PointCloud2 point_cloud_message;
+    ROSPointCloud2 point_cloud_message;
 
     while (rclcpp::ok()) {
       bool was_retrieved = rclcpp::wait_for_message(
         point_cloud_message, shared_from_this(),
-        camera_topic_, MAX_WAIT_TIME);
+        camera_topic_, kMaxWaitTime);
 
       if (!was_retrieved) {
         RCLCPP_ERROR_STREAM(
@@ -101,33 +109,165 @@ public:
     }
   }
 
-  void process_point_cloud(PointCloud2 && point_cloud)
+  /**
+   * This processes the point cloud by downsampling it, calling the clustering
+   * service, concatenating/colorizing all clustered segments into a final
+   * point cloud, then publishes it.
+   *
+   * @param point_cloud sensor_msgs/PointCloud2 message to be processed.
+   */
+  void process_point_cloud(ROSPointCloud2 point_cloud)
   {
-    auto request = std::make_shared<PCLConcatenatePointCloud::Request>();
-    request->cloud_in = point_cloud;
+    // Do this to reduce the number of total points to speed up computation
+    crop_downsample_point_cloud(point_cloud);
+
+    if (point_cloud.data.empty()) {
+      return;
+    }
+
+    auto request = std::make_shared<PCLEuclideanClusterExtraction::Request>();
+    request->cloud_in = std::move(point_cloud);
 
     auto response_future =
-      concatenate_point_cloud_client_->async_send_request(request);
+      euclidan_cluster_extraction_client_->async_send_request(request);
 
     auto response_code = rclcpp::spin_until_future_complete(
-      shared_from_this(), response_future, MAX_WAIT_TIME);
+      shared_from_this(), response_future, kMaxWaitTime);
 
     if (response_code != rclcpp::FutureReturnCode::SUCCESS) {
       RCLCPP_ERROR_STREAM(get_logger(), "Failed to recieve a response from the service");
       return;
     }
 
-    PCLConcatenatePointCloud::Response::SharedPtr response {
-      response_future.get()};
-    output_publisher_->publish(response->cloud_out);
+    std::shared_ptr response {response_future.get()};
+    output_publisher_->publish(
+      colorize_concatenate_point_clouds(
+        std::move(response->cloud_list_out),
+        std::move(request->cloud_in.header.frame_id)));
+  }
+
+  /**
+   * Reduce the number of points in a pointcloud by performing a box crop and
+   * voxel grid filter. The resulting point cloud overwrites the original.
+   *
+   *
+   * @param point_cloud sensor_msgs/PointCloud2 message to be filtered.
+   */
+  void crop_downsample_point_cloud(ROSPointCloud2 & point_cloud)
+  {
+    // Create a box of 0.5m x 0.5m x 1.0m. Depth of 1m.
+    // Downsample the point cloud by aggregating voxels for every point within
+    // 0.25mm. Note that these variables must not be given a static lifetime
+    // since Eigen::Vector<N>f is not guarenteed to be trivially constructable by constexpr
+    const Eigen::Vector4f kBoxCoordinatesMin {-0.25f, -0.25f, 0.f, 0.f};
+    const Eigen::Vector4f kBoxCoordinatesMax {0.25f, 0.25f, 1.f, 0.f};
+    const Eigen::Vector4f kVoxelGridLeafSize {0.003f, 0.003f, 0.003f, 0.f};
+
+    if (point_cloud.data.empty()) {
+      return;
+    }
+
+    auto pcl_point_cloud = std::make_shared<pcl::PointCloud<pcl::PointXYZRGB>>();
+    pcl::moveFromROSMsg(point_cloud, *pcl_point_cloud);
+
+    // Crop the point cloud, more points further away from the camera are removed
+    // This step has the greatest effect reducing points
+    pcl::CropBox<pcl::PointXYZRGB> crop_box;
+    crop_box.setMax(kBoxCoordinatesMax);
+    crop_box.setMin(kBoxCoordinatesMin);
+    crop_box.setInputCloud(pcl_point_cloud);
+    crop_box.filter(*pcl_point_cloud);
+
+    // if there are nonzero points, perform a voxel filter
+    // to reduce the number of points passed to the clustering
+    // step. This is good for reducing more points closer
+    // to the camera
+    if (!pcl_point_cloud->empty()) {
+      pcl::VoxelGrid<pcl::PointXYZRGB> voxel_grid;
+      voxel_grid.setInputCloud(pcl_point_cloud);
+      voxel_grid.setLeafSize(kVoxelGridLeafSize);
+      voxel_grid.filter(*pcl_point_cloud);
+    }
+
+    pcl::toROSMsg(*pcl_point_cloud, point_cloud);
+  }
+
+
+  /**
+   * Given a list of point clouds, apply a distinct colored tint to
+   * each point cloud, then concatenate all point clouds into one final
+   * resulting point cloud.
+   *
+   * @param point_clouds sensor_msgs/PointCloud2[] message to be colorized/concatenated.
+   * @param frame_id the frame ID of the final point cloud
+   */
+  ROSPointCloud2 colorize_concatenate_point_clouds(
+    std::vector<ROSPointCloud2> point_clouds, std::string frame_id)
+  {
+    constexpr float kTintColorWeight = 0.2f; // 60 out of 255, weight in [0.0f, 1.0f]
+    constexpr size_t kMaxNumClusters = 20U; // 18 degree minimum hue-step out of 360 per cluster
+
+    pcl::PointCloud<pcl::PointXYZRGB> pcl_temp_point_cloud;
+    pcl::PointCloud<pcl::PointXYZRGB> pcl_concatenated_point_cloud;
+
+    // HSV order, H in [0,360.f], S in [0.f, 1.f], V in [0.f, 1.f]
+    pcl::PointXYZHSV hsv_color_tint {0.0f, 1.0f, 1.0f};
+    pcl::PointXYZRGB rgb_color_tint;
+
+    size_t num_clusters = std::min(point_clouds.size(), kMaxNumClusters);
+
+    for (size_t i = 0; i < num_clusters; i++) {
+      // Adjust the hue of the point so there will be apparent differences in color
+      // between the clusters
+      hsv_color_tint.h = 360.0f * float(i) / float(num_clusters);
+
+      pcl::PointXYZHSVtoXYZRGB(hsv_color_tint, rgb_color_tint);
+      pcl::moveFromROSMsg(point_clouds[i], pcl_temp_point_cloud);
+
+      for (pcl::PointXYZRGB & point : pcl_temp_point_cloud) {
+        // Lerp the current point color with the tinted point
+        // (r, g, b) <= 255.0 + epsilon. Where epsilon is truncated via the proceeding cast.
+        float r = lerp_float(float(rgb_color_tint.r), float(point.r), kTintColorWeight);
+        float g = lerp_float(float(rgb_color_tint.g), float(point.g), kTintColorWeight);
+        float b = lerp_float(float(rgb_color_tint.b), float(point.b), kTintColorWeight);
+
+
+        // The values above will fit within uint8_t
+        // as long as (1) 0.0 <= COLOR_RANGE <= 1.0 and (2) the size of each channel in
+        // PointRGBXYZ is at most 1 byte
+        // PCL uses overlapping union members to define color, this is considered UB but
+        // there is no way around it: see https://github.com/PointCloudLibrary/pcl/issues/2303
+        point = pcl::PointXYZRGB(
+          point.x, point.y, point.z, static_cast<uint8_t>(r),
+          static_cast<uint8_t>(g), static_cast<uint8_t>(b));
+      }
+
+      // concatenate the colorized point cluster into one point cloud
+      pcl_concatenated_point_cloud += pcl_temp_point_cloud;
+    }
+
+    // convert back to a ROS message and return
+    ROSPointCloud2 output_point_cloud;
+    pcl::toROSMsg(pcl_concatenated_point_cloud, output_point_cloud);
+    output_point_cloud.header.frame_id = std::move(frame_id);
+    return output_point_cloud;
   }
 };
+
+float lerp_float(float first, float second, float factor)
+{
+  assert(factor >= 0.0f && factor <= 1.0f);
+
+  return factor * first + (1.0f - factor) * second;
+}
+
+}  // namespace
 
 int main(int argc, char ** argv)
 {
   rclcpp::init(argc, argv);
 
-  auto node = std::make_shared<TestConcatenatePointCloudNode>();
+  auto node = std::make_shared<TestEuclidanClusterExtractionNode>();
   node->spin();
 
   rclcpp::shutdown();

--- a/pcl_utilities/src/tests/simple_test_euclidean_cluster_extraction.cpp
+++ b/pcl_utilities/src/tests/simple_test_euclidean_cluster_extraction.cpp
@@ -26,22 +26,18 @@
  * Usage:
  *    `ros2 launch pcl_utilities test_euclidan_cluster_extraction.xml point_cloud_topic:=<POINT_CLOUD_TOPIC>`
  */
-#include <pcl/point_types.h>
-#include <pcl/point_cloud.h>
-#include <pcl_conversions/pcl_conversions.h>
-#include <pcl/point_types_conversion.h>
 
 #include <algorithm>  // std::min
 #include <cassert>  // assert
 #include <chrono>  // std::chrono::seconds
 #include <cstddef>  // size_t
 #include <cstdint>  // uint8_t
-#include <functional>  // std::bind, std::placeholders
 #include <memory>  // std::make_shared
 #include <string>  // std::string
 #include <utility>  // std::move
 
 #include <Eigen/Core>  // Eigen::Vector4f
+
 #include <pcl/filters/crop_box.h>
 #include <pcl/filters/voxel_grid.h>
 
@@ -54,8 +50,13 @@
 #include <rclcpp/wait_for_message.hpp>
 
 #include <pcl/pcl_config.h>
+#include <pcl/point_cloud.h>
+#include <pcl/point_types.h>
+#include <pcl/point_types_conversion.h>
+#include <pcl_conversions/pcl_conversions.h>
 
 #include <sensor_msgs/msg/point_cloud2.hpp>
+
 #include "pcl_utility_msgs/srv/pcl_euclidean_cluster_extraction.hpp"
 
 using pcl_utility_msgs::srv::PCLEuclideanClusterExtraction;

--- a/pcl_utilities/src/tests/simple_test_euclidean_cluster_extraction.cpp
+++ b/pcl_utilities/src/tests/simple_test_euclidean_cluster_extraction.cpp
@@ -46,7 +46,6 @@
 #include <rclcpp/logging.hpp>
 #include <rclcpp/node.hpp>
 #include <rclcpp/publisher.hpp>
-#include <rclcpp/subscription.hpp>
 #include <rclcpp/wait_for_message.hpp>
 
 #include <pcl/pcl_config.h>

--- a/pcl_utility_msgs/CMakeLists.txt
+++ b/pcl_utility_msgs/CMakeLists.txt
@@ -26,6 +26,7 @@ find_package(rosidl_default_generators REQUIRED)
 rosidl_generate_interfaces(${PROJECT_NAME}
   "srv/PCLVoxelGridFilter.srv"
   "srv/PCLConcatenatePointCloud.srv"
+  "srv/PCLEuclideanClusterExtraction.srv"
   DEPENDENCIES sensor_msgs
 )
 

--- a/pcl_utility_msgs/srv/PCLEuclideanClusterExtraction.srv
+++ b/pcl_utility_msgs/srv/PCLEuclideanClusterExtraction.srv
@@ -1,0 +1,4 @@
+sensor_msgs/PointCloud2 cloud_in
+---
+sensor_msgs/PointCloud2 target_cloud_out
+sensor_msgs/PointCloud2[] obstacle_cloud_list_out

--- a/pcl_utility_msgs/srv/PCLEuclideanClusterExtraction.srv
+++ b/pcl_utility_msgs/srv/PCLEuclideanClusterExtraction.srv
@@ -1,4 +1,3 @@
 sensor_msgs/PointCloud2 cloud_in
 ---
-sensor_msgs/PointCloud2 target_cloud_out
-sensor_msgs/PointCloud2[] obstacle_cloud_list_out
+sensor_msgs/PointCloud2[] cloud_list_out


### PR DESCRIPTION
# Changes

## Modified euclidean_cluster_extraction.cpp
- Return all found clusters from the service instead of only the first one
- Replaced iterator for loops with equivalent ranged for b\loops
- Replaced `std::shared_ptr` construction with `new` with equivalent `std::make_shared`
- Added in `assert` statements and `static_cast` to eliminate possibly unsafe implicit conversions. (Also good for self documentation purposes)
- Placed the class in an anonymous namespace to avoid ODR violations if duplicate symbols appear during linking.
Unlikely but possible if two classes have the same name.

## Added simple_test_euclidean_cluster_extraction.cpp
### Features
Description: Takes in a real-time camera-feed, extracts clusters, then published a new point
cloud with each cluster colored differently.
- Retrieve a point cloud from a user specified camera topic
- Down-sample the point cloud to improve performance with `pcl::CropBox` and `pcl::VoxelGrid`
- Use `euclidean_cluster_extraction` to retrieve the clusters from the point cloud
- For each cluster in the point cloud, do the following:
    - Pick a visible hue offset, create a `pcl::PointXYZHSV`, then convert the point to RGB.
    - Linear interpolate this color with the color of the point within a cluster.
    - Add the point to one final point cloud.
- Publish a `PointCloud` message to the topic with the clustered colored.
- Modified the naming convention for constants `CONSTANT -> kConstant` to follow to the style guide requirement.

### Changed
- Replaced `PointCloud&&` with `PointCloud`: This better aligns to the style guide, has the same behavior, and
better aligned with the usage of the point cloud in the code.
- Placed the class in an anonymous namespace

## Modified PCLEuclideanClusterExtraction.srv
- Replaced `target_cloud_out` and `obstacle_cloud_list_out` with `cloud_list_out` since the first point cloud is no longer assumed to be the point cloud of interest.

## Modified CMakeLists.txt
- PCL using definition for point types in `pcl/point_cloud.h` that are not standard compliant. Removed the `-pedantic` option from `simple_test_euclidean_cluster_extraction.cpp` since it produces warnings for these definitions. No warnings are produced as a result of my code.
- Moved the Clang/GCC check under build testing down to after the targets were defined.
- Updated the comment about the resolved Boost MPL/Numeric Clang compiler error.
- Added `PCL_NO_PRECOMPILE` to address issues with Address Sanitizer in `gcc`.
- Added dependency on the transitive dependency, `Eigen`, which used in the simple test.

# Compatability/Testing
All tests done on Ubuntu 22.04
| **Platform** | **Compiler**     | **Compilation** | **Asan**    | **Lsan**    | **Ubsan**    | **Simple Test** |
|:-------------|:----------------:|:---------------:|:-----------:|:-----------:|:------------:|:---------------:|
| x64          | clang++ (19.1.0) | &check;         | &check;     | &check;     | &check;      | &check;         |
| x64          | g++ (11.4.0)     | &check;         | &check; (1) | &check;     | &check;      | &check;         |
| x64          | icpx (2024.2.1)  | x (2)           | x (2)       | x (2)       | x (2)        | x (2)           |
| aarch64      | clang++ (19.1.6) | &check;         | &check;     | &check;     | &check;      | &check;         |
| aarch64      | g++ (11.4.0)     | &check;         | &check; (1) | &check;     | &check;      | &check;         |

Asan = Address Sanitizer; Lsan = Leak Sanitizer; Ubsan = Undefined Behavior Sanitizer
icpx was not tested on aarch64 since it failed on x64

1. Address sanitizer shows a heap buffer overflow of 8 bytes, however this error went away when adding the `PCL`
2. `icpx` triggered a segmentation fault on compilation. This was in the compiler itself which is very unusual but did not occur in `gcc` or `clang`. This appears to be an internal compiler issue.

## Notes
- `valgrind`: no memory errors, two shown memory unrelated memory leaks (do not result from my code).
- Compiler produces no warnings on `-Wall -Wextra`. `-Wpedantic` produces warnings only from PCL header files.
- There's a known issue in ROS2 with `new_delete_type_mismatch`, to disable the error, run
`export ASAN_OPTIONS=new_delete_type_mismatch=0`

# Results

[test.webm](https://github.com/user-attachments/assets/5b876763-ae39-4add-9a01-69118499eecc)
